### PR TITLE
Enable version placeholder in release name

### DIFF
--- a/src/DotnetDeployer.Tool/Program.cs
+++ b/src/DotnetDeployer.Tool/Program.cs
@@ -146,7 +146,10 @@ static class Program
             IsRequired = true
         };
 
-        var releaseNameOption = new Option<string?>("--release-name");
+        var releaseNameOption = new Option<string?>("--release-name")
+        {
+            Description = "Release name. Use {Version} to include the version"
+        };
         var tagOption = new Option<string?>("--tag");
         var bodyOption = new Option<string>("--body", () => string.Empty);
         var draftOption = new Option<bool>("--draft");

--- a/src/DotnetDeployer/Core/ReleaseDataExtensions.cs
+++ b/src/DotnetDeployer/Core/ReleaseDataExtensions.cs
@@ -1,0 +1,11 @@
+namespace DotnetDeployer.Core;
+
+public static class ReleaseDataExtensions
+{
+    public static ReleaseData ReplaceVersion(this ReleaseData data, string version)
+    {
+        var releaseName = data.ReleaseName.Replace("{Version}", version, StringComparison.InvariantCultureIgnoreCase);
+        var tag = data.Tag.Replace("{Version}", version, StringComparison.InvariantCultureIgnoreCase);
+        return new ReleaseData(releaseName, tag, data.ReleaseBody, data.IsDraft, data.IsPrerelease);
+    }
+}

--- a/src/DotnetDeployer/Deployer.cs
+++ b/src/DotnetDeployer/Deployer.cs
@@ -88,6 +88,7 @@ public class Deployer(Context context, Packager packager, Publisher publisher)
     // New builder-based method for creating releases
     public Task<Result> CreateGitHubRelease(ReleaseConfiguration releaseConfig, GitHubRepositoryConfig repositoryConfig, ReleaseData releaseData, bool dryRun = false)
     {
+        var resolved = releaseData.ReplaceVersion(releaseConfig.Version);
         return packagingStrategy.PackageForPlatforms(releaseConfig)
             .Bind(async files =>
             {
@@ -107,7 +108,7 @@ public class Deployer(Context context, Packager packager, Publisher publisher)
                     return Result.Success();
                 }
 
-                return await CreateGitHubRelease(files.ToList(), repositoryConfig, releaseData);
+                return await CreateGitHubRelease(files.ToList(), repositoryConfig, resolved);
             });
     }
 


### PR DESCRIPTION
## Summary
- allow placeholders in release names via `{Version}` replacement
- pipe placeholder replacement through Deployer
- document new placeholder in CLI option description

## Testing
- `dotnet restore`
- `dotnet build --no-restore`
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_688be10e73ac832fb6f6a024256f319b