### PR TITLE
Remove unsigned Android APK output

### DIFF
--- a/src/DotnetDeployer/Platforms/Android/AndroidDeployment.cs
+++ b/src/DotnetDeployer/Platforms/Android/AndroidDeployment.cs
@@ -48,13 +48,16 @@ public class AndroidDeployment(IDotnet dotnet, Path projectPath, AndroidDeployme
 
     private IEnumerable<INamedByteSource> ApkFiles(IContainer directory)
     {
+        const string signedSuffix = "-Signed";
+
         return directory.ResourcesWithPathsRecursive()
-            .Where(file => file.Name.EndsWith(".apk", StringComparison.OrdinalIgnoreCase))
+            .Where(file => file.Name.EndsWith($"{signedSuffix}.apk", StringComparison.OrdinalIgnoreCase))
             .Select(resource =>
             {
                 var originalName = global::System.IO.Path.GetFileNameWithoutExtension(resource.Name);
-                var dashIndex = originalName.LastIndexOf('-');
-                var suffix = dashIndex >= 0 ? originalName[dashIndex..] : string.Empty;
+                var withoutSigned = originalName[..^signedSuffix.Length];
+                var firstDash = withoutSigned.IndexOf('-');
+                var suffix = firstDash >= 0 ? withoutSigned[firstDash..] : string.Empty;
                 var finalName = $"{options.PackageName}-{options.ApplicationDisplayVersion}-android{suffix}.apk";
                 return (INamedByteSource)new Resource(finalName, resource);
             })

--- a/test/DotnetDeployer.Tests/ApkNamingTests.cs
+++ b/test/DotnetDeployer.Tests/ApkNamingTests.cs
@@ -7,7 +7,7 @@ namespace DotnetDeployer.Tests;
 public class ApkNamingTests
 {
     [Fact]
-    public async Task Keeps_suffix_from_original_file_name()
+    public async Task Returns_only_signed_apk_without_suffix()
     {
         var files = new Dictionary<string, IByteSource>
         {
@@ -34,8 +34,7 @@ public class ApkNamingTests
 
         result.Should().Succeed();
         result.Value.Select(x => x.Name).Should().BeEquivalentTo(
-            "AngorApp-1.0.0-android.apk",
-            "AngorApp-1.0.0-android-Signed.apk");
+            "AngorApp-1.0.0-android.apk");
     }
 
     [Fact]
@@ -68,8 +67,7 @@ public class ApkNamingTests
 
         result.Should().Succeed();
         result.Value.Select(x => x.Name).Should().BeEquivalentTo(
-            "AngorApp-1.0.0-android.apk",
-            "AngorApp-1.0.0-android-Signed.apk");
+            "AngorApp-1.0.0-android.apk");
     }
 
     private class FakeDotnet(Result<IContainer> publishResult) : IDotnet


### PR DESCRIPTION
## Summary
- only include signed Android APKs and drop `-Signed` suffix
- update tests for signed-only APK output

## Testing
- `dotnet test --no-restore` *(fails: Test Run Aborted)*

------
https://chatgpt.com/codex/tasks/task_e_688e108e93a4832fa128672066e661d0