### PR TITLE
Include commit info in packages and releases

### DIFF
--- a/src/DotnetDeployer/Core/Dotnet.cs
+++ b/src/DotnetDeployer/Core/Dotnet.cs
@@ -56,20 +56,29 @@ public class Dotnet : IDotnet
             throw new ArgumentNullException(nameof(projectPath), "Project path to pack cannot be null.");
         }
 
-        return Result.Try(() => filesystem.Directory.CreateTempSubdirectory())
-            .Map(async outputDir =>
-            {
-                var arguments = ArgumentsParser.Parse([
-                    ["output", outputDir.FullName],
-                ], [["version", version]]);
-                var result = await Command.Execute("dotnet", string.Join(" ", "pack", projectPath, arguments));
-                if (result.IsFailure)
-                {
-                    throw new InvalidOperationException(result.Error);
-                }
-                return new DirectoryContainer(outputDir);
-            })
-            .Map(directory => directory.ResourcesRecursive())
+        var directory = global::System.IO.Path.GetDirectoryName(projectPath) ?? projectPath;
+
+        return GitInfo.GetCommitInfo(directory, Command)
+            .Bind(commitInfo =>
+                Result.Try(() => filesystem.Directory.CreateTempSubdirectory())
+                    .Map(async outputDir =>
+                    {
+                        var arguments = ArgumentsParser.Parse(
+                            [["output", outputDir.FullName]],
+                            [
+                                ["version", version],
+                                ["RepositoryCommit", commitInfo.Commit],
+                                ["PackageReleaseNotes", commitInfo.Message]
+                            ]);
+
+                        var result = await Command.Execute("dotnet", string.Join(" ", "pack", projectPath, arguments));
+                        if (result.IsFailure)
+                        {
+                            throw new InvalidOperationException(result.Error);
+                        }
+                        return new DirectoryContainer(outputDir);
+                    }))
+            .Map(container => container.ResourcesRecursive())
             .Bind(sources => sources.TryFirst(file => file.Name.EndsWith(".nupkg")).ToResult("Cannot find any NuGet package in the output folder"));
     }
 }

--- a/src/DotnetDeployer/Core/GitInfo.cs
+++ b/src/DotnetDeployer/Core/GitInfo.cs
@@ -1,0 +1,30 @@
+using System.IO;
+using DotnetPackaging;
+
+namespace DotnetDeployer.Core;
+
+public record CommitInfo(string Commit, string Message);
+
+public static class GitInfo
+{
+    public static Task<Result<CommitInfo>> GetCommitInfo(string startDirectory, ICommand command)
+    {
+        return FindRepositoryRoot(new DirectoryInfo(startDirectory))
+            .Bind(root => command.Execute("git", "rev-parse HEAD", root.FullName)
+                .Bind(commit => command.Execute("git", "log -1 --pretty=%B", root.FullName)
+                    .Map(message => new CommitInfo(commit.Trim(), message.Trim()))));
+    }
+
+    static Result<DirectoryInfo> FindRepositoryRoot(DirectoryInfo? start)
+    {
+        var current = start;
+        while (current != null && !Directory.Exists(global::System.IO.Path.Combine(current.FullName, ".git")))
+        {
+            current = current.Parent;
+        }
+
+        return current != null
+            ? Result.Success(current)
+            : Result.Failure<DirectoryInfo>("Not a git repository");
+    }
+}

--- a/src/DotnetDeployer/Deployer.cs
+++ b/src/DotnetDeployer/Deployer.cs
@@ -67,6 +67,16 @@ public class Deployer(Context context, Packager packager, Publisher publisher)
         var releaseBody = releaseData.ReleaseBody;
         var isDraft = releaseData.IsDraft;
         var isPrerelease = releaseData.IsPrerelease;
+
+        var commitInfoResult = await GitInfo.GetCommitInfo(Environment.CurrentDirectory, Context.Command);
+        if (commitInfoResult.IsFailure)
+        {
+            return Result.Failure(commitInfoResult.Error);
+        }
+
+        var commitInfo = commitInfoResult.Value;
+        releaseBody = $"{releaseBody}\n\nCommit: {commitInfo.Commit}\n{commitInfo.Message}";
+
         Context.Logger.Information(
             "Creating GitHub release with files: {@Files} for owner {Owner}, repository {Repository}",
             files.Select(f => f.Name),


### PR DESCRIPTION
## Summary
- add helper to obtain git commit and message
- embed commit hash and message into generated NuGet packages
- append commit details to GitHub releases

## Testing
- `dotnet test` *(fails: Test Run Aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68947b9f753c832f8380b72c3ad1151b