### PR TITLE
Ensure CLI fails on command errors

### DIFF
--- a/src/DotnetDeployer.Tool/ConsoleMixin.cs
+++ b/src/DotnetDeployer.Tool/ConsoleMixin.cs
@@ -5,17 +5,19 @@ namespace DotnetDeployer.Tool;
 
 public static class ConsoleMixin
 {
-    public static void WriteResult(this Result result)
+    public static int WriteResult(this Result result)
     {
         result
             .Tap(() => Log.Information("Success"))
             .TapError(Log.Error);
+        return result.IsSuccess ? 0 : 1;
     }
-    
-    public static async Task WriteResult(this Task<Result> result)
+
+    public static async Task<int> WriteResult(this Task<Result> result)
     {
-        await result
+        var final = await result
             .Tap(() => Log.Information("Success"))
             .TapError(Log.Error);
+        return final.IsSuccess ? 0 : 1;
     }
 }

--- a/src/DotnetDeployer.Tool/Program.cs
+++ b/src/DotnetDeployer.Tool/Program.cs
@@ -108,7 +108,8 @@ static class Program
                 ? projects.Select(p => p.FullName)
                 : DiscoverPackableProjects(solution, pattern).Select(f => f.FullName);
 
-            await Deployer.Instance.PublishNugetPackages(projectList.ToList(), version, apiKey, push: !noPush)
+            ctx.ExitCode = await Deployer.Instance
+                .PublishNugetPackages(projectList.ToList(), version, apiKey, push: !noPush)
                 .WriteResult();
         });
 
@@ -319,7 +320,8 @@ static class Program
             var repositoryConfig = new GitHubRepositoryConfig(owner!, repository!, token);
             var releaseData = new ReleaseData(releaseName, tag, body, draft, prerelease);
 
-            await deployer.CreateGitHubRelease(releaseConfig, repositoryConfig, releaseData, dryRun)
+            context.ExitCode = await deployer
+                .CreateGitHubRelease(releaseConfig, repositoryConfig, releaseData, dryRun)
                 .WriteResult();
         });
 


### PR DESCRIPTION
## Summary
- propagate external command failure by returning proper exit codes

## Testing
- `dotnet test` *(fails: Test run aborted after hang)*

------
https://chatgpt.com/codex/tasks/task_e_6895bc0139bc832fb6f0ff21881cf12a