### PR TITLE
Android: select signed APK by ApplicationId; discovery logging and Result-based release build

### DIFF
--- a/src/DotnetDeployer/Core/ReleaseBuilder.cs
+++ b/src/DotnetDeployer/Core/ReleaseBuilder.cs
@@ -237,18 +237,20 @@ public class ReleaseBuilder(Context context)
     }
     
     
-    public ReleaseConfiguration Build()
+    public Result<ReleaseConfiguration> Build()
     {
         if (string.IsNullOrWhiteSpace(configuration.Version))
         {
-            throw new InvalidOperationException("Version is required. Use WithVersion() first.");
+            context.Logger.Warn("Release build failed: Version is missing. Use WithVersion() first.");
+            return Result.Failure<ReleaseConfiguration>("Version is required. Use WithVersion() first.");
         }
         
         if (configuration.Platforms == TargetPlatform.None)
         {
-            throw new InvalidOperationException("At least one platform must be specified.");
+            context.Logger.Warn("Release build failed: No platforms specified.");
+            return Result.Failure<ReleaseConfiguration>("At least one platform must be specified.");
         }
         
-        return configuration;
+        return Result.Success(configuration);
     }
 }

--- a/src/DotnetDeployer/Deployer.cs
+++ b/src/DotnetDeployer/Deployer.cs
@@ -137,11 +137,11 @@ public class Deployer(Context context, Packager packager, Publisher publisher)
     // - Avalonia.iOS (for iOS, if applicable)
     public Task<Result> CreateGitHubReleaseForAvalonia(string avaloniaSolutionPath, string version, string packageName, string appId, string appName, GitHubRepositoryConfig repositoryConfig, ReleaseData releaseData, AndroidDeployment.DeploymentOptions? androidOptions = null)
     {
-        var releaseConfig = CreateRelease()
+        var releaseConfigResult = CreateRelease()
             .WithApplicationInfo(packageName, appId, appName)
             .ForAvaloniaProjectsFromSolution(avaloniaSolutionPath, version, androidOptions)
             .Build();
 
-        return CreateGitHubRelease(releaseConfig, repositoryConfig, releaseData);
+        return releaseConfigResult.Bind(rc => CreateGitHubRelease(rc, repositoryConfig, releaseData));
     }
 }


### PR DESCRIPTION
This PR improves Android packaging and release UX:

- Separate PackageName (artifact naming) and ApplicationId (Android APK filtering).
- Select only APKs that contain the ApplicationId and end with -Signed.apk; log all discovered APKs and the selected ones.
- Add discovery logs in the CLI (parsed projects, chosen prefix) and provide prefix hints. If nothing matches, suggest a likely --prefix.
- Make ReleaseBuilder.Build return Result<ReleaseConfiguration> instead of throwing; the CLI handles failures gracefully with clear logs.
- Fix TF_BUILD build-number update to avoid empty error in Result.SuccessIf.
- Improve dry-run UX and diagnostics.

Tested with dry-run and with Android build to confirm APK selection by ApplicationId.
