### PR TITLE
Improve CLI clarity and robustness: rename flags, infer app-id, and fix UpdateBuildNumber exception

### DIFF
--- a/src/DotnetDeployer.Tool/DotnetDeployer.Tool.csproj
+++ b/src/DotnetDeployer.Tool/DotnetDeployer.Tool.csproj
@@ -7,11 +7,13 @@
     <PackAsTool>true</PackAsTool>
     <RollForward>LatestMajor</RollForward>
     <ToolCommandName>dotnetdeployer</ToolCommandName>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="DotnetPackaging" />
     <PackageReference Include="Serilog.Sinks.Console" />
     <PackageReference Include="System.CommandLine" />
+    <PackageReference Include="Zafiro.DivineBytes" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DotnetDeployer\DotnetDeployer.csproj" />


### PR DESCRIPTION
This PR improves the usability and robustness of the DotnetDeployer.Tool CLI:

- Rename flags for clarity
  - --dry-run is renamed to --no-publish to reflect actual behavior (build/package but do not publish). --dry-run remains as a deprecated alias and emits a warning.
  - --token is renamed to --github-token to make clear it is GitHub’s API token for release publishing. --token remains as a deprecated alias and emits a warning.

- Fix exception on UpdateBuildNumber
  - UpdateBuildNumber no longer uses Result.SuccessIf with a null/empty error message, which caused ArgumentNullException in environments without TF_BUILD. It now short-circuits to success when TF_BUILD is not set.

- Better defaults
  - When --app-id is omitted, infer it from the solution (same as already done for package-name and app-name). This avoids null AppId scenarios that could lead to downstream errors.

- Tool packaging resilience
  - Add explicit reference to Zafiro.DivineBytes and enable CopyLocalLockFileAssemblies=true in the tool project to help dependency resolution in tool packaging/execution scenarios.

Motivation
- Users reported an “Unhandled exception: ArgumentNullException” when running the tool outside of Azure DevOps due to UpdateBuildNumber expecting TF_BUILD and constructing a failure result with a null error.
- The --dry-run flag was confusing because it still performs building/packaging; renaming to --no-publish communicates the behavior more accurately.
- The --token name was ambiguous; --github-token clarifies purpose.
- Inferring --app-id improves DX and reduces boilerplate in common cases.

Changes
- CLI
  - New: --no-publish
  - Deprecated: --dry-run (still supported, warns)
  - New: --github-token
  - Deprecated: --token (still supported, warns)
- Behavior
  - Auto-infer app-id when omitted
  - UpdateBuildNumber returns success if TF_BUILD is not set
- Packaging
  - Add PackageReference to Zafiro.DivineBytes
  - Set CopyLocalLockFileAssemblies=true

Backward compatibility
- The deprecated flags still work but log warnings:
  - --dry-run (use --no-publish)
  - --token (use --github-token)

Migration guide
- Replace:
  - --dry-run → --no-publish
  - --token → --github-token

Testing
- dotnet run (local) validated parsing, inference, and non-publish flow:
  - release --solution <path> --prefix <Prefix> --version 0.2.6 --platform linux --no-publish --github-token DUMMY
- Verified solution-based discovery logs and Linux packaging path.
- Verified that missing TF_BUILD no longer throws.

CI/CD
- No changes required in pipelines. After merge, the tool should auto-publish per existing azure-pipelines configuration.

Checklist
- [x] Renamed flags with deprecation warnings
- [x] Fixed UpdateBuildNumber exception
- [x] Added app-id inference
- [x] Ensured dependency packaging improvements
- [x] Local test runs for non-publish scenario