### PR TITLE
Packaging: quote and normalize PackageReleaseNotes to avoid MSBuild argument splitting in CI

### DIFF
--- a/src/DotnetDeployer/Core/Dotnet.cs
+++ b/src/DotnetDeployer/Core/Dotnet.cs
@@ -68,7 +68,7 @@ public class Dotnet : IDotnet
                             [
                                 ["version", version],
                                 ["RepositoryCommit", commitInfo.Commit],
-                                ["PackageReleaseNotes", commitInfo.Message]
+                                ["PackageReleaseNotes", QuoteMsBuildPropertyValue(NormalizeReleaseNotes(commitInfo.Message))]
                             ]);
 
                         var finalArguments = string.Join(" ", "pack", projectPath, arguments);
@@ -78,5 +78,18 @@ public class Dotnet : IDotnet
                     }))
             .Map(container => container.ResourcesRecursive())
             .Bind(sources => sources.TryFirst(file => file.Name.EndsWith(".nupkg")).ToResult("Cannot find any NuGet package in the output folder"));
+    }
+
+    private static string NormalizeReleaseNotes(string message)
+    {
+        if (string.IsNullOrEmpty(message)) return string.Empty;
+        var normalized = message.Replace("\r", string.Empty).Replace("\n", "\\n");
+        normalized = normalized.Replace("\"", "'");
+        return normalized;
+    }
+
+    private static string QuoteMsBuildPropertyValue(string value)
+    {
+        return $"\"{value}\"";
     }
 }


### PR DESCRIPTION
Fix packaging failure in Azure Pipelines when passing multi-line/space-containing commit messages as PackageReleaseNotes.

Problem
- In CI, MSBuild interpreted PackageReleaseNotes as multiple tokens (e.g., 'Merge', 'pull', 'request', ...) causing MSB1008 (only one project can be specified) because the value was not quoted.

Solution
- Normalize newlines in the commit message to escaped \n so the property is one token.
- Surround the value in double quotes to force MSBuild to treat it as a single argument.

Implementation
- In DotnetDeployer.Core.Dotnet.Pack, apply NormalizeReleaseNotes and QuoteMsBuildPropertyValue to PackageReleaseNotes.

Impact
- Prevents CI packaging step from failing when commit messages contain newlines or spaces.
- No behavior changes outside of packaging metadata; purely build robustness.

Testing
- Local build verified argument construction.
- CI should pass packing step on next run.