### PR TITLE
fix(nuget): escape ; = % in PackageReleaseNotes (preserve structure)

### DIFF
--- a/src/DotnetDeployer/Core/Dotnet.cs
+++ b/src/DotnetDeployer/Core/Dotnet.cs
@@ -87,6 +87,11 @@ public class Dotnet : IDotnet
         var normalized = message.Replace("\r\n", "\n").Replace("\r", "\n");
         // Replace double quotes to avoid breaking the surrounding quotes used in -p:Property="..."
         normalized = normalized.Replace("\"", "'");
+        // Escape characters that MSBuild interprets in /p: assignments: '%', ';', '='
+        // Order matters: escape '%' first to avoid re-escaping the percent in %3B and %3D
+        normalized = normalized.Replace("%", "%25");
+        normalized = normalized.Replace(";", "%3B");
+        normalized = normalized.Replace("=", "%3D");
         // Encode newlines as literal two-character sequence \n
         normalized = normalized.Replace("\n", "\\n");
         return normalized.Trim();

--- a/test/DotnetDeployer.Tests/ReleaseNotesEscapingTests.cs
+++ b/test/DotnetDeployer.Tests/ReleaseNotesEscapingTests.cs
@@ -19,9 +19,14 @@ public class ReleaseNotesEscapingTests
         result.Should().Contain("\\n");
         // No double quotes remain
         result.Should().NotContain("\"");
-        // Commas and semicolons are preserved
+        // Commas are preserved
         result.Should().Contain(",");
-        result.Should().Contain(";");
+        // Semicolons are escaped to %3B for MSBuild /p parsing safety
+        result.Should().Contain("%3B");
+        // Percent signs are escaped to %25
+        result.Should().Contain("%25");
+        // Equals signs are escaped to %3D
+        Dotnet.NormalizeReleaseNotes("A=B").Should().Contain("%3D");
         // Double quotes replaced by single quotes
         result.Should().Contain("'and'");
         result.Should().NotBeNullOrWhiteSpace();


### PR DESCRIPTION
MSBuild splits /p: assignments by semicolons and treats '=' and '%' specially.\n\nThis PR updates PackageReleaseNotes normalization to:\n- Encode ';' => %3B, '=' => %3D, '%' => %25 (escape order matters)\n- Preserve commit structure: unify CR/LF and emit literal \n\n- Replace double quotes with single quotes to keep -p:"..." intact\n\nAdds/updates tests to validate escaping and structure.\n\nIf checks pass, auto-merge is enabled.