### PR TITLE
fix(nuget): bullet '-' escaping and proper no-push failure propagation

### DIFF
--- a/src/DotnetDeployer/Core/Dotnet.cs
+++ b/src/DotnetDeployer/Core/Dotnet.cs
@@ -92,8 +92,10 @@ public class Dotnet : IDotnet
         normalized = normalized.Replace("%", "%25");
         normalized = normalized.Replace(";", "%3B");
         normalized = normalized.Replace("=", "%3D");
-        // Encode newlines as literal two-character sequence \n
+        // Encode newlines as literal two-character sequence \\n
         normalized = normalized.Replace("\n", "\\n");
+        // Prevent leading dash after a logical newline from being treated as a switch by MSBuild tokenization
+        normalized = normalized.Replace("\\n- ", "\\n\\- ");
         return normalized.Trim();
     }
 

--- a/src/DotnetDeployer/Deployer.cs
+++ b/src/DotnetDeployer/Deployer.cs
@@ -46,9 +46,14 @@ public class Deployer(Context context, Packager packager, Publisher publisher)
             .CombineSequentially()
             ;
 
-        if (packagesResult.IsFailure || !push)
+        if (packagesResult.IsFailure)
         {
-            return packagesResult.Map(_ => Result.Success()).GetValueOrDefault(Result.Success());
+            return Result.Failure(packagesResult.Error);
+        }
+
+        if (!push)
+        {
+            return Result.Success();
         }
 
         return await packagesResult.Value

--- a/test/DotnetDeployer.Tests/ReleaseNotesEscapingTests.cs
+++ b/test/DotnetDeployer.Tests/ReleaseNotesEscapingTests.cs
@@ -29,6 +29,8 @@ public class ReleaseNotesEscapingTests
         Dotnet.NormalizeReleaseNotes("A=B").Should().Contain("%3D");
         // Double quotes replaced by single quotes
         result.Should().Contain("'and'");
+        // Hyphen at start of a bullet after a newline is escaped to avoid being parsed as a switch
+        Dotnet.NormalizeReleaseNotes("First\n- Bullet").Should().Contain("\\n\\- ");
         result.Should().NotBeNullOrWhiteSpace();
     }
 }


### PR DESCRIPTION
Address two issues found while packing:\n\n1) MSBuild parsing of '-' bullets after logical newlines: escape to \n\- so they don't become switches even if a parser materializes newlines.\n2) PublishNugetPackages incorrectly swallowed pack failures when --no-push; now failures propagate.\n\nIncludes tests. Auto-merge enabled if checks pass.