### PR TITLE
docs: add README and WASM Pages docs; publish WASM to Pages; detect default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,185 @@
+# DotnetDeployer
+
+Deployment and packaging helper for .NET solutions. It provides:
+- A CLI to publish NuGet packages and create GitHub releases with multi-platform artifacts (Windows, Linux, Android, WebAssembly).
+- High-level automation that discovers projects in your solution, builds artifacts, and optionally publishes a GitHub release.
+- Optional WebAssembly site generation and deployment to GitHub Pages.
+
+Notes:
+- Conversations and issue discussions may be in Spanish, but code and commit messages are in English.
+- Target frameworks: library/tool target net8.0; tests target net9.0.
+
+## Prerequisites
+- .NET 8 SDK
+- Git (for release and Pages workflows)
+- GitHub token with repo permissions for creating releases and pushing to Pages
+- For Android packaging: a signing keystore (base64) and credentials
+
+## Build and Test
+- Restore and build the full solution:
+  - `dotnet build DotnetDeployer.sln -c Release`
+- Run all tests:
+  - `dotnet test test/DotnetDeployer.Tests -c Release`
+- Run only unit tests (exclude Integration by namespace):
+  - `dotnet test test/DotnetDeployer.Tests -c Release --filter "FullyQualifiedName!~Integration"`
+- Run a specific test:
+  - `dotnet test test/DotnetDeployer.Tests -c Release --filter "FullyQualifiedName=DotnetDeployer.Tests.ApkNamingTests.Returns_only_signed_apk_without_suffix"`
+  - `dotnet test test/DotnetDeployer.Tests -c Release --filter "FullyQualifiedName~ApkNamingTests"`
+- Formatting (if you have dotnet-format):
+  - `dotnet format --verify-no-changes`
+  - `dotnet format`
+
+## CLI Overview
+Run from source:
+- `dotnet run --project src/DotnetDeployer.Tool -- --help`
+
+Commands:
+- `nuget`: discover and pack projects, optionally push to NuGet.
+- `release`: discover platform projects, package artifacts, and optionally publish a GitHub release. Can also deploy a WASM site to GitHub Pages.
+
+Secrets:
+- Prefer environment variables. Do not print secrets.
+  - `NUGET_API_KEY` for NuGet pushes
+  - `GITHUB_TOKEN` for GitHub release creation and Pages deployment
+
+---
+
+## Command: nuget
+Publish NuGet packages from discovered projects in a solution (or explicit projects).
+
+Key options:
+- `--solution` Path to the solution (.sln). If omitted, the tool searches upward in parent directories.
+- `--project` One or more explicit csproj files to pack (bypasses auto discovery).
+- `--version` Semver to use. If omitted, version is inferred using GitVersion (falls back to `git describe`).
+- `--api-key` NuGet API key (can be provided via `NUGET_API_KEY`).
+- `--name-pattern` Wildcard to narrow auto-discovery (e.g., `YourApp*`).
+- `--no-push` Only pack; do not push to NuGet.
+
+Examples:
+- Using env var for the API key (recommended):
+  - `export NUGET_API_KEY={{NUGET_API_KEY}}`
+  - `dotnet run --project src/DotnetDeployer.Tool -- nuget --solution DotnetDeployer.sln --version 1.2.3`
+- Explicit projects and only pack (no push):
+  - `dotnet run --project src/DotnetDeployer.Tool -- nuget --project src/DotnetDeployer/DotnetDeployer.csproj --version 1.2.3 --no-push`
+- Discovery with name pattern (excludes tests/demos/samples/desktop by convention):
+  - `dotnet run --project src/DotnetDeployer.Tool -- nuget --solution path/to/YourApp.sln --name-pattern "YourApp*" --version 1.2.3`
+
+---
+
+## Command: release
+Create artifacts per platform and optionally publish a GitHub release with uploaded assets.
+
+Platform discovery rules (by project suffix):
+- `.Desktop` => Windows and/or Linux (self-contained executables)
+- `.Browser` => WebAssembly (WASM) site
+- `.Android` => Signed Android APKs
+
+General options:
+- `--solution` Solution file. If omitted, the tool searches parent directories.
+- `--prefix` Prefix to narrow project discovery inside the solution. Defaults to the solution name.
+- `--version` Release version. If omitted, GitVersion is used (fallback to `git describe`).
+- `--package-name`, `--app-id`, `--app-name` App metadata. If omitted, reasonable defaults are inferred from the solution name. For Android, `--app-id` may be read from the Android csproj `<ApplicationId>`.
+- `--owner`, `--repository` GitHub owner and repository. If omitted, inferred from the current git remote (origin).
+- `--github-token` GitHub token (or `--token` deprecated alias). Can be provided via `GITHUB_TOKEN` env var.
+- `--release-name`, `--tag`, `--body`, `--draft`, `--prerelease` Standard GitHub release metadata.
+- `--no-publish` Build/package artifacts but do not publish a GitHub release (preferred over deprecated `--dry-run`).
+- `--platform` One or more of: `windows`, `linux`, `android`, `wasm`.
+
+Android options:
+- `--android-keystore-base64`, `--android-key-alias`, `--android-key-pass`, `--android-store-pass` Signing credentials.
+- `--android-app-version` Integer ApplicationVersion. If omitted, generated from semantic version.
+- `--android-app-display-version` Display string for version name (defaults to `--version`).
+
+WebAssembly (current behavior):
+- If WebAssembly is requested and discovered, the tool generates the site (wwwroot) and attempts to deploy it to GitHub Pages in the same repository used for the release.
+- The default branch for the Pages repository is detected via the GitHub API. If detection fails, a safe default is used (currently `main`).
+- If Pages deployment fails, the GitHub release creation still succeeds; a warning is logged.
+
+Examples:
+- Full example (Windows + Linux + Android + WASM) without publishing yet:
+  - `export GITHUB_TOKEN={{GITHUB_TOKEN}}`
+  - `export ANDROID_KEYSTORE_BASE64={{ANDROID_KEYSTORE_B64}}`
+  - `dotnet run --project src/DotnetDeployer.Tool -- release \`
+    `--solution /abs/path/YourApp.sln \`
+    `--version 1.2.3 \`
+    `--package-name YourApp \`
+    `--app-id com.example.yourapp \`
+    `--app-name "Your App" \`
+    `--platform windows linux android wasm \`
+    `--android-keystore-base64 "$ANDROID_KEYSTORE_BASE64" \`
+    `--android-key-alias {{ANDROID_KEY_ALIAS}} \`
+    `--android-key-pass {{ANDROID_KEY_PASS}} \`
+    `--android-store-pass {{ANDROID_STORE_PASS}} \`
+    `--no-publish`
+
+- Publish for Windows and Linux only (auto-discovery with default prefix):
+  - `export GITHUB_TOKEN={{GITHUB_TOKEN}}`
+  - `dotnet run --project src/DotnetDeployer.Tool -- release --solution /abs/path/YourApp.sln --version 1.2.3 --platform windows linux`
+
+- Create artifacts but skip release publication:
+  - `export GITHUB_TOKEN={{GITHUB_TOKEN}}`
+  - `dotnet run --project src/DotnetDeployer.Tool -- release --solution /abs/path/YourApp.sln --version 1.2.3 --no-publish`
+
+---
+
+## WebAssembly to GitHub Pages: separate repository (Planned)
+Some teams prefer hosting the WASM site in a different repository than the one used for releases. The planned enhancement will allow specifying a separate Pages repository for WebAssembly.
+
+Proposed API (subject to change):
+```csharp
+var result = await deployer.CreateRelease()
+    .ForSolution("/abs/path/YourApp.sln")
+    .ForRepository(owner: "acme", repository: "yourapp", apiKey: githubToken)
+    .WithVersion("1.2.3")
+    .WithPackageName("YourApp")
+    .TargetPlatforms(TargetPlatform.Windows | TargetPlatform.Linux | TargetPlatform.WebAssembly)
+    .ConfigureWebAssembly(cfg => cfg
+        .Project("src/YourApp.Browser/YourApp.Browser.csproj")
+        .PagesRepository(owner: "acme", repository: "yourapp-pages", branch: "gh-pages")) // branch optional
+    .Run();
+```
+
+Proposed CLI flags (subject to change):
+- `--wasm-project PATH`
+- `--wasm-pages-owner OWNER`
+- `--wasm-pages-repository REPO`
+- `--wasm-pages-branch BRANCH` (optional)
+
+Example (planned):
+- `export GITHUB_TOKEN={{GITHUB_TOKEN}}`
+- `dotnet run --project src/DotnetDeployer.Tool -- release \`
+  `--solution /abs/path/YourApp.sln \`
+  `--version 1.2.3 \`
+  `--package-name YourApp \`
+  `--platform windows linux wasm \`
+  `--owner acme --repository yourapp \`
+  `--wasm-project src/YourApp.Browser/YourApp.Browser.csproj \`
+  `--wasm-pages-owner acme \`
+  `--wasm-pages-repository yourapp-pages \`
+  `--wasm-pages-branch gh-pages`
+
+Branch resolution when omitted (planned):
+- Attempt to detect the repository default branch via the GitHub API.
+- Fallback to a common branch name such as `gh-pages` or `main`.
+
+---
+
+## Security notes
+- Prefer environment variables for secrets. Do not echo them to the console.
+- Avoid printing tokens in logs or command output. The tool consumes `GITHUB_TOKEN` and `NUGET_API_KEY` via environment variables or explicit flags.
+- For Android, pass the keystore as Base64 (e.g., `ANDROID_KEYSTORE_BASE64`) and provide passwords via environment variables.
+
+## Troubleshooting
+- Version inference:
+  - If `--version` is omitted, the tool tries GitVersion; if that fails, it falls back to `git describe`.
+- Owner/repo inference:
+  - If `--owner`/`--repository` are omitted, they are inferred from `git remote origin`.
+- Project discovery:
+  - If discovery fails for your prefix, the tool logs available prefixes based on `.Desktop`, `.Browser`, `.Android` projects found in the solution.
+- Pages deployment:
+  - Pages deployment is best-effort. Failures do not cancel the GitHub release; check logs for the warning and run the Pages step separately if needed.
+
+---
+
+© DotnetDeployer contributors.
+

--- a/src/DotnetDeployer/Core/ReleasePackagingStrategy.cs
+++ b/src/DotnetDeployer/Core/ReleasePackagingStrategy.cs
@@ -1,5 +1,7 @@
 namespace DotnetDeployer.Core;
 
+using DotnetDeployer.Platforms.Wasm;
+
 public class ReleasePackagingStrategy
 {
     private readonly Packager packager;
@@ -92,5 +94,10 @@ public class ReleasePackagingStrategy
         }
 
         return Result.Success<IEnumerable<INamedByteSource>>(allFiles);
+    }
+
+    public Task<Result<WasmApp>> CreateWasmSite(string projectPath)
+    {
+        return packager.CreateWasmSite(projectPath);
     }
 }


### PR DESCRIPTION
This PR adds a comprehensive README documenting CLI usage (nuget and release), platform behaviors, examples, security notes, and troubleshooting.\n\nHighlights:\n- docs: add comprehensive README with CLI usage and planned WASM Pages separate repository support.\n- feat: detect GitHub default branch for Pages deployment and log it.\n- feat: publish WASM site to GitHub Pages during release; failures do not fail the release.\n- chore: expose CreateWasmSite from ReleasePackagingStrategy.\n\nCloses: n/a