### PR TITLE
Add export CLI and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,52 @@ Examples:
 
 ---
 
+## Command: export
+Build artifacts for selected platforms and write them to a target directory without publishing anything.
+
+Behavior and discovery mirror the release command:
+- Project discovery by suffix: `.Desktop` (Windows/Linux), `.Browser` (WASM), `.Android` (Android).
+- Use `--prefix` to guide discovery when your solution contains multiple app roots.
+
+Key options:
+- `--solution` Solution file. If omitted, the tool searches parent directories.
+- `--prefix` Prefix for discovery. Defaults to the solution name.
+- `--version` Artifacts version. If omitted, GitVersion is used (fallback to `git describe`).
+- `--package-name`, `--app-id`, `--app-name` App metadata. If omitted, inferred from the solution name.
+- `--platform` One or more of: `windows`, `linux`, `android`, `wasm`.
+- `--output` Output directory where artifacts will be written. Required.
+- `--include-wasm` If set and `wasm` is included in `--platform`, writes the WASM site contents into a `wasm` subfolder.
+
+Android options:
+- `--android-keystore-base64`, `--android-key-alias`, `--android-key-pass`, `--android-store-pass` Signing credentials.
+- `--android-app-version` Integer ApplicationVersion (auto-generated from semver if omitted).
+- `--android-app-display-version` Display string for version name (defaults to `--version`).
+
+Notes:
+- No GitHub token is needed for export.
+- For Linux packaging, the tool builds for the current machine architecture by default (e.g., linux-x64 on x64 hosts).
+
+Examples:
+- Export Windows + Linux:
+  - `dotnet run --project src/DotnetDeployer.Tool -- export --solution /abs/path/YourApp.sln --version 1.2.3 --platform windows linux --output /abs/path/out`
+- Export Android (requires signing):
+  - `export ANDROID_KEYSTORE_BASE64={{ANDROID_KEYSTORE_B64}}`
+  - `dotnet run --project src/DotnetDeployer.Tool -- export \`
+    `--solution /abs/path/YourApp.sln \`
+    `--version 1.2.3 \`
+    `--package-name YourApp \`
+    `--app-id com.example.yourapp \`
+    `--platform android \`
+    `--android-keystore-base64 "$ANDROID_KEYSTORE_BASE64" \`
+    `--android-key-alias {{ANDROID_KEY_ALIAS}} \`
+    `--android-key-pass {{ANDROID_KEY_PASS}} \`
+    `--android-store-pass {{ANDROID_STORE_PASS}} \`
+    `--output /abs/path/out`
+- Export Linux + WASM, including site:
+  - `dotnet run --project src/DotnetDeployer.Tool -- export --solution /abs/path/YourApp.sln --version 1.2.3 --platform linux wasm --include-wasm --output /abs/path/out`
+
+---
+
 ## WebAssembly to GitHub Pages: separate repository (Planned)
 Some teams prefer hosting the WASM site in a different repository than the one used for releases. The planned enhancement will allow specifying a separate Pages repository for WebAssembly.
 

--- a/WARP.md
+++ b/WARP.md
@@ -52,9 +52,31 @@ Ejemplos:
 ### Uso del comando "release" del CLI
 Crea artefactos por plataforma (Windows, Linux, Android, WebAssembly) y, opcionalmente, una release en GitHub con subida de assets.
 
+### Uso del comando "export" del CLI
+Genera los artefactos por plataforma y los escribe en una carpeta indicada, sin publicar nada.
+
+- Descubre proyectos en la solución igual que "release" y acepta las mismas opciones de plataformas y Android.
+- Directorio de salida: requerido con --output.
+- WASM: por defecto no exporta el sitio; puedes incluirlo con --include-wasm (se escribirá en un subdirectorio "wasm").
+
+Ejemplo:
+- dotnet run --project src/DotnetDeployer.Tool -- export \
+    --solution /abs/path/YourApp.sln \
+    --version 1.2.3 \
+    --package-name YourApp \
+    --app-id com.example.yourapp \
+    --app-name "Your App" \
+    --platform windows linux android wasm \
+    --android-keystore-base64 "$ANDROID_KEYSTORE_BASE64" \
+    --android-key-alias {{ANDROID_KEY_ALIAS}} \
+    --android-key-pass {{ANDROID_KEY_PASS}} \
+    --android-store-pass {{ANDROID_STORE_PASS}} \
+    --include-wasm \
+    --output /path/to/out
+
 - Autodescubre proyectos en la solución según sufijos: .Desktop (Windows/Linux), .Browser (WASM), .Android (Android). Puedes guiar con --prefix.
 - Token GitHub: --github-token o env var GITHUB_TOKEN. Owner/repo inferidos de "git remote origin" si no se pasan --owner y --repository.
-- --no-publish genera artefactos sin crear la release (alias deprecado: --dry-run).
+- --no-publish genera artefactos sin crear la release (alias deprecado: --dry-run). Con --no-publish no se requiere token de GitHub ni owner/repository.
 - Android: requiere firma. Pasa el keystore en Base64 y credenciales; si no das --android-app-version, se deriva de la semver.
 
 Ejemplo completo (Windows+Linux+Android+WASM) sin publicar aún:

--- a/src/DotnetDeployer/Deployer.cs
+++ b/src/DotnetDeployer/Deployer.cs
@@ -1,5 +1,6 @@
 using DotnetDeployer.Core;
 using DotnetDeployer.Platforms.Android;
+using DotnetDeployer.Platforms.Wasm;
 using DotnetDeployer.Services.GitHub;
 using DotnetPackaging;
 using Zafiro.CSharpFunctionalExtensions;
@@ -165,6 +166,18 @@ Context.Logger.Warn("GitHub Pages deployment failed: {Error}", pagesResult.Error
     public ReleaseBuilder CreateRelease()
     {
         return new ReleaseBuilder(Context);
+    }
+
+    // Expose packaging-only flow (no publishing)
+    public Task<Result<IEnumerable<INamedByteSource>>> BuildArtifacts(ReleaseConfiguration releaseConfig)
+    {
+        return packagingStrategy.PackageForPlatforms(releaseConfig);
+    }
+
+    // Expose WASM site creation
+    public Task<Result<WasmApp>> CreateWasmSite(string projectPath)
+    {
+        return packagingStrategy.CreateWasmSite(projectPath);
     }
 
     // Convenience method for automatic Avalonia project discovery


### PR DESCRIPTION
Add 'export' command to build artifacts without publishing and write them to an output directory.\n\nHighlights:\n- New CLI command: export (mirrors discovery and options of 'release')\n- Supports windows, linux, android, wasm; optional --include-wasm to write the site under 'wasm' subfolder\n- No GitHub token required for export\n- README and WARP.md updated with usage examples\n- release: --no-publish now skips owner/repo and token requirements\n\nInternal:\n- Deployer exposes BuildArtifacts and CreateWasmSite for packaging-only flows\n- Linux packaging builds for current machine architecture by default to avoid cross-publish failures