### PR TITLE
Add option to select Android package format

### DIFF
--- a/src/DotnetDeployer/Platforms/Android/AndroidPackageFormat.cs
+++ b/src/DotnetDeployer/Platforms/Android/AndroidPackageFormat.cs
@@ -1,0 +1,26 @@
+namespace DotnetDeployer.Platforms.Android;
+
+public enum AndroidPackageFormat
+{
+    Apk,
+    Aab
+}
+
+public static class AndroidPackageFormatExtensions
+{
+    public static string ToMsBuildValue(this AndroidPackageFormat format) => format switch
+    {
+        AndroidPackageFormat.Apk => "apk",
+        AndroidPackageFormat.Aab => "aab",
+        _ => "apk"
+    };
+
+    public static string FileExtension(this AndroidPackageFormat format) => format switch
+    {
+        AndroidPackageFormat.Apk => ".apk",
+        AndroidPackageFormat.Aab => ".aab",
+        _ => ".apk"
+    };
+
+    public static bool RequiresSignedSuffix(this AndroidPackageFormat format) => format == AndroidPackageFormat.Apk;
+}

--- a/test/DotnetDeployer.Tests/ApkNamingTests.cs
+++ b/test/DotnetDeployer.Tests/ApkNamingTests.cs
@@ -72,6 +72,38 @@ public class ApkNamingTests
             "AngorApp-1.0.0-android.apk");
     }
 
+    [Fact]
+    public async Task When_aab_format_requested_produces_aab_file()
+    {
+        var files = new Dictionary<string, IByteSource>
+        {
+            ["io.Angor.AngorApp.aab"] = ByteSource.FromString("a"),
+        };
+
+        var container = files.ToRootContainer().Value;
+        var dotnet = new FakeDotnet(Result.Success<IContainer>(container));
+
+        var options = new AndroidDeployment.DeploymentOptions
+        {
+            PackageName = "AngorApp",
+            ApplicationId = "io.Angor.AngorApp",
+            ApplicationVersion = 1,
+            ApplicationDisplayVersion = "1.0.0",
+            AndroidSigningKeyStore = ByteSource.FromString("dummy"),
+            SigningKeyAlias = "alias",
+            SigningStorePass = "store",
+            SigningKeyPass = "key",
+            PackageFormat = AndroidPackageFormat.Aab
+        };
+
+        var deployment = new AndroidDeployment(dotnet, new Path("project.csproj"), options, Maybe<ILogger>.None);
+        var result = await deployment.Create();
+
+        result.Should().Succeed();
+        result.Value.Select(x => x.Name).Should().BeEquivalentTo(
+            "AngorApp-1.0.0-android.aab");
+    }
+
     private class FakeDotnet(Result<IContainer> publishResult) : IDotnet
     {
         public Task<Result<IContainer>> Publish(string projectPath, string arguments = "") => Task.FromResult(publishResult);


### PR DESCRIPTION
## Summary
- add `--android-package-format` option with `.apk` default for release/export commands
- generalize Android packaging pipeline to honor `.apk` or `.aab`
- cover `.aab` renaming with unit tests

## Testing
- `dotnet test DotnetDeployer.sln` *(fails: VSTest handshake timeout in CI sandbox)*