### PR TITLE
Add Windows icon resolver for Windows packages

### DIFF
--- a/src/DotnetDeployer/Platforms/Windows/WindowsIcon.cs
+++ b/src/DotnetDeployer/Platforms/Windows/WindowsIcon.cs
@@ -1,0 +1,27 @@
+namespace DotnetDeployer.Platforms.Windows;
+
+public class WindowsIcon(string path, bool shouldCleanup)
+{
+    public string Path { get; } = path;
+    public bool ShouldCleanup { get; } = shouldCleanup;
+
+    public void Cleanup()
+    {
+        if (!ShouldCleanup)
+        {
+            return;
+        }
+
+        try
+        {
+            if (File.Exists(Path))
+            {
+                File.Delete(Path);
+            }
+        }
+        catch
+        {
+            // Best effort cleanup
+        }
+    }
+}

--- a/src/DotnetDeployer/Platforms/Windows/WindowsIconResolver.cs
+++ b/src/DotnetDeployer/Platforms/Windows/WindowsIconResolver.cs
@@ -1,0 +1,438 @@
+using System.Buffers.Binary;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using IOPath = System.IO.Path;
+
+namespace DotnetDeployer.Platforms.Windows;
+
+public class WindowsIconResolver(Maybe<ILogger> logger)
+{
+    private static readonly Regex IconAttributeRegex = new(@"Icon=""(?<path>[^""]+)""", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly Regex WindowIconRegex = new(@"WindowIcon\((?:@)?""(?<path>[^""\r\n]+)""", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly string[] PreferredExtensions = [".ico", ".png", ".svg"];
+    private static readonly string[] PreferredNames = ["appicon", "icon", "logo"];
+
+    public Result<Maybe<WindowsIcon>> Resolve(Path projectPath)
+    {
+        var projectFile = projectPath.ToString();
+        var projectDirectory = global::System.IO.Path.GetDirectoryName(projectFile);
+
+        if (projectDirectory is null)
+        {
+            return Result.Success(Maybe<WindowsIcon>.None);
+        }
+
+        var candidate = FindIconCandidate(projectFile, projectDirectory);
+
+        if (candidate.HasNoValue)
+        {
+            logger.Execute(log => log.Debug("No Windows icon candidate detected for {Project}", projectFile));
+            return Result.Success(Maybe<WindowsIcon>.None);
+        }
+
+        return PrepareIcon(candidate.Value, projectDirectory)
+            .Map(icon => Maybe<WindowsIcon>.From(icon))
+            .OnFailureCompensate(error =>
+            {
+                logger.Execute(log => log.Warning("Failed to prepare Windows icon for {Project}: {Error}", projectFile, error));
+                return Result.Success(Maybe<WindowsIcon>.None);
+            });
+    }
+
+    private Maybe<IconReference> FindIconCandidate(string projectFile, string projectDirectory)
+    {
+        var projectFileIcon = FindIconInProjectFile(projectFile);
+        if (projectFileIcon.HasValue)
+        {
+            return projectFileIcon;
+        }
+
+        var xamlIcon = FindIconInXaml(projectDirectory);
+        if (xamlIcon.HasValue)
+        {
+            return xamlIcon;
+        }
+
+        var codeIcon = FindIconInCodeBehind(projectDirectory);
+        if (codeIcon.HasValue)
+        {
+            return codeIcon;
+        }
+
+        return FindIconByScanning(projectDirectory);
+    }
+
+    private Maybe<IconReference> FindIconInProjectFile(string projectFile)
+    {
+        if (!File.Exists(projectFile))
+        {
+            return Maybe<IconReference>.None;
+        }
+
+        try
+        {
+            var document = XDocument.Load(projectFile);
+            var applicationIcon = document.Descendants().FirstOrDefault(element => element.Name.LocalName == "ApplicationIcon");
+            var value = applicationIcon?.Value?.Trim();
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                return Maybe<IconReference>.From(new IconReference(value, false));
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.Execute(log => log.Warning(ex, "Unable to parse project file {ProjectFile} while looking for ApplicationIcon", projectFile));
+        }
+
+        return Maybe<IconReference>.None;
+    }
+
+    private Maybe<IconReference> FindIconInXaml(string projectDirectory)
+    {
+        foreach (var file in EnumerateFiles(projectDirectory, "*.axaml"))
+        {
+            try
+            {
+                var content = File.ReadAllText(file);
+                var match = IconAttributeRegex.Match(content);
+                if (match.Success)
+                {
+                    var value = match.Groups["path"].Value.Trim();
+                    var reference = InterpretResourceReference(value);
+                    if (reference.HasValue)
+                    {
+                        return reference;
+                    }
+
+                    return Maybe<IconReference>.From(new IconReference(value, false));
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.Execute(log => log.Debug(ex, "Failed to inspect {File} while looking for Icon attribute", file));
+            }
+        }
+
+        return Maybe<IconReference>.None;
+    }
+
+    private Maybe<IconReference> FindIconInCodeBehind(string projectDirectory)
+    {
+        foreach (var file in EnumerateFiles(projectDirectory, "*.cs"))
+        {
+            try
+            {
+                var content = File.ReadAllText(file);
+                var match = WindowIconRegex.Match(content);
+                if (match.Success)
+                {
+                    var value = match.Groups["path"].Value.Trim();
+                    var reference = InterpretResourceReference(value);
+                    if (reference.HasValue)
+                    {
+                        return reference;
+                    }
+
+                    return Maybe<IconReference>.From(new IconReference(value, false));
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.Execute(log => log.Debug(ex, "Failed to inspect {File} while looking for WindowIcon construction", file));
+            }
+        }
+
+        return Maybe<IconReference>.None;
+    }
+
+    private Maybe<IconReference> FindIconByScanning(string projectDirectory)
+    {
+        var candidateDirectories = GetCandidateDirectories(projectDirectory);
+
+        var files = candidateDirectories
+            .Where(Directory.Exists)
+            .SelectMany(directory => EnumerateFiles(directory, "*.*"))
+            .Select(file => new { file, extension = IOPath.GetExtension(file) })
+            .Where(item => PreferredExtensions.Contains(item.extension, StringComparer.OrdinalIgnoreCase))
+            .Where(item => FileLooksLikeIcon(item.file));
+
+        var best = files
+            .OrderBy(item => Array.IndexOf(PreferredExtensions, item.extension.ToLowerInvariant()))
+            .ThenByDescending(item => new FileInfo(item.file).Length)
+            .Select(item => item.file)
+            .FirstOrDefault();
+
+        if (best is null)
+        {
+            return Maybe<IconReference>.None;
+        }
+
+        return Maybe<IconReference>.From(new IconReference(best, true));
+    }
+
+    private Result<WindowsIcon> PrepareIcon(IconReference reference, string projectDirectory)
+    {
+        var iconPath = reference.ToAbsolute(projectDirectory);
+
+        if (!File.Exists(iconPath))
+        {
+            return Result.Failure<WindowsIcon>($"Icon candidate '{iconPath}' does not exist");
+        }
+
+        var extension = IOPath.GetExtension(iconPath).ToLowerInvariant();
+
+        return extension switch
+        {
+            ".ico" => Result.Success(new WindowsIcon(iconPath, false)),
+            ".png" => CreateIconFromPng(iconPath),
+            ".svg" => ResolveSvg(iconPath),
+            _ => Result.Failure<WindowsIcon>($"Unsupported icon format '{extension}' for Windows packaging")
+        };
+    }
+
+    private Result<WindowsIcon> CreateIconFromPng(string pngPath)
+    {
+        return Result.Try(() => File.ReadAllBytes(pngPath))
+            .Bind(bytes => CreateIconFromPngBytes(bytes));
+    }
+
+    private Result<WindowsIcon> CreateIconFromPngBytes(byte[] pngBytes)
+    {
+        return GetPngDimensions(pngBytes)
+            .Bind(dimensions => CreateIconFile(pngBytes, dimensions.Width, dimensions.Height));
+    }
+
+    private Result<WindowsIcon> ResolveSvg(string svgPath)
+    {
+        var fallback = FindRasterFallback(svgPath);
+
+        if (fallback.HasNoValue)
+        {
+            logger.Execute(log => log.Warning("Skipping SVG icon at {SvgPath} because no raster fallback was found", svgPath));
+            return Result.Failure<WindowsIcon>("Unable to prepare a Windows icon from SVG without a PNG fallback");
+        }
+
+        logger.Execute(log => log.Information("Using raster fallback {Fallback} for SVG icon {SvgPath}", fallback.Value, svgPath));
+        return CreateIconFromPng(fallback.Value);
+    }
+
+    private Result<(byte Width, byte Height)> GetPngDimensions(byte[] pngBytes)
+    {
+        return Result.Try(() =>
+        {
+            var signature = new byte[] { 137, 80, 78, 71, 13, 10, 26, 10 };
+            if (pngBytes.Length < 24)
+            {
+                throw new InvalidOperationException("PNG data is too short to contain dimensions");
+            }
+
+            for (var i = 0; i < signature.Length; i++)
+            {
+                if (pngBytes[i] != signature[i])
+                {
+                    throw new InvalidOperationException("Invalid PNG signature");
+                }
+            }
+
+            var span = new ReadOnlySpan<byte>(pngBytes);
+            var width = BinaryPrimitives.ReadUInt32BigEndian(span.Slice(16, 4));
+            var height = BinaryPrimitives.ReadUInt32BigEndian(span.Slice(20, 4));
+
+            if (width == 0 || height == 0)
+            {
+                throw new InvalidOperationException("PNG dimensions cannot be zero");
+            }
+
+            var widthByte = width >= 256 ? (byte)0 : (byte)width;
+            var heightByte = height >= 256 ? (byte)0 : (byte)height;
+
+            return (widthByte, heightByte);
+        });
+    }
+
+    private Result<WindowsIcon> CreateIconFile(byte[] imageBytes, byte width, byte height)
+    {
+        return Result.Try(() =>
+        {
+            var tempFile = IOPath.Combine(IOPath.GetTempPath(), $"{Guid.NewGuid():N}.ico");
+            using var stream = new FileStream(tempFile, FileMode.Create, FileAccess.Write, FileShare.None);
+            using var writer = new BinaryWriter(stream);
+
+            writer.Write((ushort)0);
+            writer.Write((ushort)1);
+            writer.Write((ushort)1);
+            writer.Write(width == 0 ? (byte)0 : width);
+            writer.Write(height == 0 ? (byte)0 : height);
+            writer.Write((byte)0);
+            writer.Write((byte)0);
+            writer.Write((ushort)0);
+            writer.Write((ushort)32);
+            writer.Write(imageBytes.Length);
+            writer.Write(6 + 16);
+            writer.Write(imageBytes);
+
+            return new WindowsIcon(tempFile, true);
+        });
+    }
+
+    private IEnumerable<string> GetCandidateDirectories(string projectDirectory)
+    {
+        var candidates = new List<string>
+        {
+            projectDirectory,
+            IOPath.Combine(projectDirectory, "Assets"),
+            IOPath.Combine(projectDirectory, "Assets", "Icons"),
+            IOPath.Combine(projectDirectory, "Assets", "Images"),
+            IOPath.Combine(projectDirectory, "Resources"),
+            IOPath.Combine(projectDirectory, "Resources", "Icons"),
+            IOPath.Combine(projectDirectory, "Images"),
+            IOPath.Combine(projectDirectory, "Icons")
+        };
+
+        return candidates.Distinct(StringComparer.OrdinalIgnoreCase);
+    }
+
+    private Maybe<string> FindRasterFallback(string svgPath)
+    {
+        var direct = IOPath.ChangeExtension(svgPath, ".png");
+        if (direct is not null && File.Exists(direct))
+        {
+            return Maybe<string>.From(direct);
+        }
+
+        var directory = IOPath.GetDirectoryName(svgPath);
+        if (directory is null || !Directory.Exists(directory))
+        {
+            return Maybe<string>.None;
+        }
+
+        var svgName = IOPath.GetFileNameWithoutExtension(svgPath);
+        var matching = Directory.EnumerateFiles(directory, "*.png", SearchOption.TopDirectoryOnly)
+            .FirstOrDefault(file => string.Equals(IOPath.GetFileNameWithoutExtension(file), svgName, StringComparison.OrdinalIgnoreCase));
+
+        if (matching is not null)
+        {
+            return Maybe<string>.From(matching);
+        }
+
+        var any = Directory.EnumerateFiles(directory, "*.png", SearchOption.TopDirectoryOnly).FirstOrDefault();
+        return any is not null ? Maybe<string>.From(any) : Maybe<string>.None;
+    }
+
+    private static bool FileLooksLikeIcon(string path)
+    {
+        var fileName = IOPath.GetFileNameWithoutExtension(path).ToLowerInvariant();
+        return PreferredNames.Any(name => fileName.Contains(name, StringComparison.Ordinal)) ||
+               path.Contains("icon", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static IEnumerable<string> EnumerateFiles(string root, string searchPattern)
+    {
+        var stack = new Stack<string>();
+        stack.Push(root);
+
+        while (stack.Count > 0)
+        {
+            var current = stack.Pop();
+            IEnumerable<string> files;
+            try
+            {
+                files = Directory.EnumerateFiles(current, searchPattern, SearchOption.TopDirectoryOnly);
+            }
+            catch
+            {
+                continue;
+            }
+
+            foreach (var file in files)
+            {
+                yield return file;
+            }
+
+            IEnumerable<string> directories;
+            try
+            {
+                directories = Directory.EnumerateDirectories(current, "*", SearchOption.TopDirectoryOnly);
+            }
+            catch
+            {
+                continue;
+            }
+
+            foreach (var directory in directories)
+            {
+                var name = IOPath.GetFileName(directory);
+                if (string.Equals(name, "bin", StringComparison.OrdinalIgnoreCase) || string.Equals(name, "obj", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                stack.Push(directory);
+            }
+        }
+    }
+
+    private Maybe<IconReference> InterpretResourceReference(string value)
+    {
+        if (value.StartsWith("avares://", StringComparison.OrdinalIgnoreCase))
+        {
+            var remaining = value.Substring("avares://".Length);
+            var slashIndex = remaining.IndexOf('/') + 1;
+            if (slashIndex <= 0 || slashIndex >= remaining.Length)
+            {
+                return Maybe<IconReference>.None;
+            }
+
+            var relative = remaining[slashIndex..];
+            return Maybe<IconReference>.From(new IconReference(relative.Replace('/', IOPath.DirectorySeparatorChar), false));
+        }
+
+        if (value.StartsWith("resm:", StringComparison.OrdinalIgnoreCase))
+        {
+            var resource = value.Substring("resm:".Length);
+            var queryIndex = resource.IndexOf('?');
+            if (queryIndex >= 0)
+            {
+                resource = resource[..queryIndex];
+            }
+
+            var segments = resource.Split('.', StringSplitOptions.RemoveEmptyEntries);
+            if (segments.Length < 2)
+            {
+                return Maybe<IconReference>.None;
+            }
+
+            var withoutAssembly = segments.Skip(1).ToList();
+            if (withoutAssembly.Count >= 2)
+            {
+                var fileSegments = withoutAssembly.TakeLast(2).ToArray();
+                withoutAssembly = withoutAssembly.SkipLast(2).ToList();
+                withoutAssembly.Add(string.Join('.', fileSegments));
+            }
+
+            var relative = IOPath.Combine(withoutAssembly.ToArray());
+            return Maybe<IconReference>.From(new IconReference(relative, false));
+        }
+
+        if (IOPath.IsPathRooted(value))
+        {
+            return Maybe<IconReference>.From(new IconReference(value, true));
+        }
+
+        value = value.TrimStart('/', '\\');
+        return string.IsNullOrWhiteSpace(value) ? Maybe<IconReference>.None : Maybe<IconReference>.From(new IconReference(value, false));
+    }
+
+    private readonly record struct IconReference(string Value, bool IsAbsolute)
+    {
+        public string ToAbsolute(string projectDirectory)
+        {
+            if (IsAbsolute)
+            {
+                return Value;
+            }
+
+            return IOPath.GetFullPath(IOPath.Combine(projectDirectory, Value.Replace('/', IOPath.DirectorySeparatorChar)));
+        }
+    }
+}

--- a/test/DotnetDeployer.Tests/WindowsDeploymentTests.cs
+++ b/test/DotnetDeployer.Tests/WindowsDeploymentTests.cs
@@ -1,0 +1,54 @@
+using DotnetDeployer.Core;
+using DotnetDeployer.Platforms.Windows;
+using FluentAssertions;
+
+namespace DotnetDeployer.Tests;
+
+public class WindowsDeploymentTests
+{
+    [Fact]
+    public async Task Adds_application_icon_property_when_icon_detected()
+    {
+        using var sandbox = new WindowsIconResolverTests.TemporaryProject();
+
+        sandbox.WriteProjectFile();
+        sandbox.WriteFile("Assets/icon.png", WindowsIconResolverTests.SamplePng);
+        sandbox.WriteText("MainWindow.axaml", "<Window xmlns=\"https://github.com/avaloniaui\" Icon=\"Assets/icon.png\" />");
+
+        var files = new Dictionary<string, IByteSource>
+        {
+            ["TestApp.exe"] = ByteSource.FromString("exe")
+        };
+
+        var container = files.ToRootContainer().Value;
+        var dotnet = new RecordingDotnet(Result.Success<IContainer>(container));
+
+        var deployment = new WindowsDeployment(dotnet, new Path(sandbox.ProjectPath), new WindowsDeployment.DeploymentOptions
+        {
+            PackageName = "TestApp",
+            Version = "1.0.0"
+        }, Maybe<ILogger>.None);
+
+        var result = await deployment.Create();
+
+        result.Should().Succeed();
+        dotnet.Arguments.Should().NotBeEmpty();
+        dotnet.Arguments.Should().AllSatisfy(argument => argument.Should().Contain("ApplicationIcon"));
+        result.Value.Should().HaveCount(2);
+    }
+
+    private sealed class RecordingDotnet(Result<IContainer> publishResult) : IDotnet
+    {
+        public List<string> Arguments { get; } = new();
+
+        public Task<Result<IContainer>> Publish(string projectPath, string arguments = "")
+        {
+            Arguments.Add(arguments);
+            return Task.FromResult(publishResult);
+        }
+
+        public Task<Result> Push(string packagePath, string apiKey) => Task.FromResult(Result.Success());
+
+        public Task<Result<INamedByteSource>> Pack(string projectPath, string version) => Task.FromResult(Result.Failure<INamedByteSource>("Not implemented"));
+    }
+}

--- a/test/DotnetDeployer.Tests/WindowsIconResolverTests.cs
+++ b/test/DotnetDeployer.Tests/WindowsIconResolverTests.cs
@@ -34,6 +34,28 @@ public class WindowsIconResolverTests
     }
 
     [Fact]
+    public void Resolves_icon_when_resource_path_starts_with_slash()
+    {
+        using var sandbox = new TemporaryProject();
+
+        sandbox.WriteProjectFile();
+        sandbox.WriteFile("Assets/icon.png", SamplePng);
+        sandbox.WriteText("MainWindow.axaml", "<Window xmlns=\"https://github.com/avaloniaui\" Icon=\"/Assets/icon.png\" />");
+
+        var resolver = new WindowsIconResolver(Maybe<ILogger>.None);
+
+        var result = resolver.Resolve(new Path(sandbox.ProjectPath));
+
+        result.IsSuccess.Should().BeTrue();
+        var icon = result.Value;
+        icon.HasValue.Should().BeTrue();
+        var value = icon.Value;
+        IOPath.GetExtension(value.Path).Should().Be(".ico");
+        File.Exists(value.Path).Should().BeTrue();
+        value.Cleanup();
+    }
+
+    [Fact]
     public void Uses_png_sibling_for_svg_icon()
     {
         using var sandbox = new TemporaryProject();

--- a/test/DotnetDeployer.Tests/WindowsIconResolverTests.cs
+++ b/test/DotnetDeployer.Tests/WindowsIconResolverTests.cs
@@ -1,0 +1,140 @@
+using DotnetDeployer.Platforms.Windows;
+using FluentAssertions;
+using IOPath = System.IO.Path;
+
+namespace DotnetDeployer.Tests;
+
+public class WindowsIconResolverTests
+{
+    internal static readonly byte[] SamplePng = Convert.FromBase64String(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/xcAArgB9VDsp94AAAAASUVORK5CYII=");
+
+    [Fact]
+    public void Resolves_icon_from_avares_reference()
+    {
+        using var sandbox = new TemporaryProject();
+
+        sandbox.WriteProjectFile();
+        sandbox.WriteFile("Assets/icon.png", SamplePng);
+        sandbox.WriteText("MainWindow.axaml", "<Window xmlns=\"https://github.com/avaloniaui\" Icon=\"avares://TestApp/Assets/icon.png\" />");
+
+        var resolver = new WindowsIconResolver(Maybe<ILogger>.None);
+
+        var result = resolver.Resolve(new Path(sandbox.ProjectPath));
+
+        result.IsSuccess.Should().BeTrue();
+        var icon = result.Value;
+        icon.HasValue.Should().BeTrue();
+        var value = icon.Value;
+        IOPath.GetExtension(value.Path).Should().Be(".ico");
+        File.Exists(value.Path).Should().BeTrue();
+        value.ShouldCleanup.Should().BeTrue();
+        value.Cleanup();
+        File.Exists(value.Path).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Uses_png_sibling_for_svg_icon()
+    {
+        using var sandbox = new TemporaryProject();
+
+        sandbox.WriteProjectFile();
+        sandbox.WriteText("Assets/icon.svg", "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"32\" height=\"32\"><rect width=\"32\" height=\"32\" fill=\"#FF0000\"/></svg>");
+        sandbox.WriteFile("Assets/icon.png", SamplePng);
+        sandbox.WriteText("MainWindow.axaml", "<Window xmlns=\"https://github.com/avaloniaui\" Icon=\"Assets/icon.svg\" />");
+
+        var resolver = new WindowsIconResolver(Maybe<ILogger>.None);
+
+        var result = resolver.Resolve(new Path(sandbox.ProjectPath));
+
+        result.IsSuccess.Should().BeTrue();
+        var icon = result.Value;
+        icon.HasValue.Should().BeTrue();
+        var value = icon.Value;
+        IOPath.GetExtension(value.Path).Should().Be(".ico");
+        File.Exists(value.Path).Should().BeTrue();
+        value.Cleanup();
+    }
+
+    [Fact]
+    public void Returns_none_when_svg_without_raster_fallback()
+    {
+        using var sandbox = new TemporaryProject();
+
+        sandbox.WriteProjectFile();
+        sandbox.WriteText("Assets/icon.svg", "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"32\" height=\"32\"><rect width=\"32\" height=\"32\" fill=\"#FF0000\"/></svg>");
+        sandbox.WriteText("MainWindow.axaml", "<Window xmlns=\"https://github.com/avaloniaui\" Icon=\"Assets/icon.svg\" />");
+
+        var resolver = new WindowsIconResolver(Maybe<ILogger>.None);
+
+        var result = resolver.Resolve(new Path(sandbox.ProjectPath));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.HasValue.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Falls_back_to_scanning_for_icon_like_names()
+    {
+        using var sandbox = new TemporaryProject();
+
+        sandbox.WriteProjectFile();
+        sandbox.WriteFile("Assets/Logo.png", SamplePng);
+
+        var resolver = new WindowsIconResolver(Maybe<ILogger>.None);
+
+        var result = resolver.Resolve(new Path(sandbox.ProjectPath));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.HasValue.Should().BeTrue();
+        var icon = result.Value.Value;
+        icon.Path.Should().EndWith(".ico");
+        File.Exists(icon.Path).Should().BeTrue();
+        icon.Cleanup();
+    }
+
+    internal sealed class TemporaryProject : IDisposable
+    {
+        public TemporaryProject()
+        {
+            Root = System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Root);
+            Directory.CreateDirectory(System.IO.Path.Combine(Root, "Assets"));
+        }
+
+        public string Root { get; }
+        public string ProjectPath => System.IO.Path.Combine(Root, "TestApp.csproj");
+
+        public void WriteProjectFile()
+        {
+            const string content = "<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup></Project>";
+            File.WriteAllText(ProjectPath, content);
+        }
+
+        public void WriteFile(string relativePath, byte[] contents)
+        {
+            var fullPath = System.IO.Path.Combine(Root, relativePath);
+            Directory.CreateDirectory(System.IO.Path.GetDirectoryName(fullPath)!);
+            File.WriteAllBytes(fullPath, contents);
+        }
+
+        public void WriteText(string relativePath, string contents)
+        {
+            var fullPath = System.IO.Path.Combine(Root, relativePath);
+            Directory.CreateDirectory(System.IO.Path.GetDirectoryName(fullPath)!);
+            File.WriteAllText(fullPath, contents);
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                Directory.Delete(Root, true);
+            }
+            catch
+            {
+                // ignore
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a Windows icon resolver that discovers icon candidates, converts PNG assets into ICOs, and falls back when only SVG references exist
- plug the resolver into the Windows deployment flow so the generated executables receive the ApplicationIcon MSBuild property and temporary icons are cleaned up
- add tests covering the resolver heuristics and the Windows deployment arguments

## Testing
- `dotnet build`
- `dotnet test test/DotnetDeployer.Tests/DotnetDeployer.Tests.csproj --logger "console;verbosity=minimal"` *(fails: vstest connection timed out in the current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2b9352620832f84888cb46ddd1744