### PR TITLE
fix: use project android target framework when packaging

### DIFF
--- a/src/DotnetDeployer/Msbuild/MsbuildMetadataExtractor.cs
+++ b/src/DotnetDeployer/Msbuild/MsbuildMetadataExtractor.cs
@@ -15,6 +15,8 @@ public class MsbuildMetadataExtractor : IMsbuildMetadataExtractor
     private static readonly string[] PropertiesToExtract =
     [
         "AssemblyName",
+        "TargetFramework",
+        "TargetFrameworks",
         "Version",
         "Authors",
         "Description",
@@ -62,6 +64,11 @@ public class MsbuildMetadataExtractor : IMsbuildMetadataExtractor
             {
                 ProjectPath = projectPath,
                 AssemblyName = assemblyName,
+                TargetFramework = properties.GetValueOrDefault("TargetFramework"),
+                TargetFrameworks = properties.GetValueOrDefault("TargetFrameworks"),
+                AndroidTargetFramework = ResolveAndroidTargetFramework(
+                    properties.GetValueOrDefault("TargetFramework"),
+                    properties.GetValueOrDefault("TargetFrameworks")),
                 Version = properties.GetValueOrDefault("Version"),
                 Authors = properties.GetValueOrDefault("Authors"),
                 Description = properties.GetValueOrDefault("Description"),
@@ -74,6 +81,15 @@ public class MsbuildMetadataExtractor : IMsbuildMetadataExtractor
                 RepositoryUrl = properties.GetValueOrDefault("RepositoryUrl")
             };
         });
+    }
+
+    private static string? ResolveAndroidTargetFramework(string? targetFramework, string? targetFrameworks)
+    {
+        var candidates = new[] { targetFramework, targetFrameworks }
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .SelectMany(value => value!.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
+
+        return candidates.FirstOrDefault(candidate => candidate.Contains("-android", StringComparison.OrdinalIgnoreCase));
     }
 
     private static async Task<string?> GetProperty(string projectPath, string propertyName)

--- a/src/DotnetDeployer/Msbuild/ProjectMetadata.cs
+++ b/src/DotnetDeployer/Msbuild/ProjectMetadata.cs
@@ -9,6 +9,9 @@ public record ProjectMetadata
 {
     public required string ProjectPath { get; init; }
     public required string AssemblyName { get; init; }
+    public string? TargetFramework { get; init; }
+    public string? TargetFrameworks { get; init; }
+    public string? AndroidTargetFramework { get; init; }
     public string? Version { get; init; }
     public string? Authors { get; init; }
     public string? Description { get; init; }

--- a/src/DotnetDeployer/Packaging/Android/AabGenerator.cs
+++ b/src/DotnetDeployer/Packaging/Android/AabGenerator.cs
@@ -46,13 +46,15 @@ public class AabGenerator : IPackageGenerator
         if (signing.IsConfigured)
             logger.Information("AAB will be release-signed");
 
+        var targetFramework = metadata.AndroidTargetFramework ?? "net9.0-android";
+
         // Run dotnet publish for Android with AAB output
         var versionArgs = AndroidVersionHelper.GetVersionArgs(metadata.Version);
         var signingArgs = signing.GetSigningArgs();
-        logger.Debug("Running: dotnet publish -c Release -f net9.0-android -p:AndroidPackageFormat=aab {VersionArgs} {SigningArgs}", versionArgs, signingArgs);
+        logger.Debug("Running: dotnet publish -c Release -f {TargetFramework} -p:AndroidPackageFormat=aab {VersionArgs} {SigningArgs}", targetFramework, versionArgs, signingArgs);
         var publishResult = await command.Execute(
             "dotnet",
-            $"publish \"{projectPath}\" -c Release -f net9.0-android -p:AndroidPackageFormat=aab {versionArgs} {signingArgs}",
+            $"publish \"{projectPath}\" -c Release -f {targetFramework} -p:AndroidPackageFormat=aab {versionArgs} {signingArgs}",
             projectDir);
 
         if (publishResult.IsFailure)
@@ -65,8 +67,8 @@ public class AabGenerator : IPackageGenerator
         // Search for AAB in multiple possible locations
         var searchDirs = new[]
         {
-            IOPath.Combine(projectDir, "bin", "Release", "net9.0-android", "publish"),
-            IOPath.Combine(projectDir, "bin", "Release", "net9.0-android"),
+            IOPath.Combine(projectDir, "bin", "Release", targetFramework, "publish"),
+            IOPath.Combine(projectDir, "bin", "Release", targetFramework),
             IOPath.Combine(projectDir, "bin", "Release")
         };
 

--- a/src/DotnetDeployer/Packaging/Android/ApkGenerator.cs
+++ b/src/DotnetDeployer/Packaging/Android/ApkGenerator.cs
@@ -46,13 +46,15 @@ public class ApkGenerator : IPackageGenerator
         if (signing.IsConfigured)
             logger.Information("APK will be release-signed");
 
+        var targetFramework = metadata.AndroidTargetFramework ?? "net9.0-android";
+
         // Run dotnet publish for Android
         var versionArgs = AndroidVersionHelper.GetVersionArgs(metadata.Version);
         var signingArgs = signing.GetSigningArgs();
-        logger.Debug("Running: dotnet publish -c Release -f net9.0-android {VersionArgs} {SigningArgs}", versionArgs, signingArgs);
+        logger.Debug("Running: dotnet publish -c Release -f {TargetFramework} {VersionArgs} {SigningArgs}", targetFramework, versionArgs, signingArgs);
         var publishResult = await command.Execute(
             "dotnet",
-            $"publish \"{projectPath}\" -c Release -f net9.0-android {versionArgs} {signingArgs}",
+            $"publish \"{projectPath}\" -c Release -f {targetFramework} {versionArgs} {signingArgs}",
             projectDir);
 
         if (publishResult.IsFailure)
@@ -65,8 +67,8 @@ public class ApkGenerator : IPackageGenerator
         // Search for APK in multiple possible locations
         var searchDirs = new[]
         {
-            IOPath.Combine(projectDir, "bin", "Release", "net9.0-android", "publish"),
-            IOPath.Combine(projectDir, "bin", "Release", "net9.0-android"),
+            IOPath.Combine(projectDir, "bin", "Release", targetFramework, "publish"),
+            IOPath.Combine(projectDir, "bin", "Release", targetFramework),
             IOPath.Combine(projectDir, "bin", "Release")
         };
 

--- a/test/DotnetDeployer.Tests/Platforms/Android/AndroidTargetFrameworkTests.cs
+++ b/test/DotnetDeployer.Tests/Platforms/Android/AndroidTargetFrameworkTests.cs
@@ -1,0 +1,116 @@
+using CSharpFunctionalExtensions;
+using DotnetDeployer.Domain;
+using DotnetDeployer.Msbuild;
+using DotnetDeployer.Packaging;
+using DotnetDeployer.Packaging.Android;
+using Serilog;
+using Zafiro.Commands;
+
+namespace DotnetDeployer.Tests.Platforms.Android;
+
+public class AndroidTargetFrameworkTests : IDisposable
+{
+    private readonly string tempDir = Path.Combine(Path.GetTempPath(), $"DotnetDeployer.Tests.{Guid.NewGuid():N}");
+
+    public AndroidTargetFrameworkTests()
+    {
+        Directory.CreateDirectory(tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(tempDir))
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Extractor_ShouldReadAndroidTargetFramework_FromTargetFramework()
+    {
+        var projectPath = CreateProject("""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0-android</TargetFramework>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        var extractor = new MsbuildMetadataExtractor();
+
+        var result = await extractor.Extract(projectPath);
+
+        Assert.True(result.IsSuccess, result.IsFailure ? result.Error : "Expected extraction to succeed.");
+        Assert.Equal("net10.0-android", result.Value.AndroidTargetFramework);
+    }
+
+    [Fact]
+    public async Task Extractor_ShouldSelectAndroidTargetFramework_FromTargetFrameworks()
+    {
+        var projectPath = CreateProject("""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFrameworks>net10.0;net10.0-android;net10.0-ios</TargetFrameworks>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        var extractor = new MsbuildMetadataExtractor();
+
+        var result = await extractor.Extract(projectPath);
+
+        Assert.True(result.IsSuccess, result.IsFailure ? result.Error : "Expected extraction to succeed.");
+        Assert.Equal("net10.0-android", result.Value.AndroidTargetFramework);
+    }
+
+    [Theory]
+    [InlineData(typeof(ApkGenerator), "app-Signed.apk", "apk")]
+    [InlineData(typeof(AabGenerator), "app.aab", "aab")]
+    public async Task AndroidGenerators_ShouldPublishUsingMetadataTargetFramework(Type generatorType, string foundFileName, string expectedExtension)
+    {
+        var projectDir = Directory.CreateDirectory(Path.Combine(tempDir, "src", "App")).FullName;
+        var outputDir = Directory.CreateDirectory(Path.Combine(tempDir, "out")).FullName;
+        var projectPath = Path.Combine(projectDir, "App.csproj");
+        await File.WriteAllTextAsync(projectPath, "<Project />");
+
+        var targetFramework = "net10.0-android";
+        var publishDir = Directory.CreateDirectory(Path.Combine(projectDir, "bin", "Release", targetFramework, "publish")).FullName;
+        await File.WriteAllTextAsync(Path.Combine(publishDir, foundFileName), "dummy");
+
+        var command = new RecordingCommand();
+        var metadata = new ProjectMetadata
+        {
+            ProjectPath = projectPath,
+            AssemblyName = "App",
+            IconPath = Maybe<string>.None,
+            AndroidTargetFramework = targetFramework
+        };
+
+        var generator = (IPackageGenerator)Activator.CreateInstance(generatorType, command, null)!;
+        var logger = new LoggerConfiguration().CreateLogger();
+        var result = await generator.Generate(projectPath, Architecture.Arm64, metadata, outputDir, logger);
+
+        Assert.True(result.IsSuccess, result.IsFailure ? result.Error : "Expected package generation to succeed.");
+        Assert.Contains($"-f {targetFramework}", command.Arguments);
+        Assert.DoesNotContain("-f net9.0-android", command.Arguments);
+        Assert.EndsWith($".{expectedExtension}", result.Value.FileName);
+    }
+
+    private string CreateProject(string contents)
+    {
+        var projectPath = Path.Combine(tempDir, $"{Guid.NewGuid():N}.csproj");
+        File.WriteAllText(projectPath, contents);
+        return projectPath;
+    }
+
+    private sealed class RecordingCommand : ICommand
+    {
+        public string Arguments { get; private set; } = "";
+
+        public Task<Result<string>> Execute(string command, string arguments, string workingDirectory = "", Dictionary<string, string>? environmentVariables = null)
+        {
+            Arguments = arguments;
+            return Task.FromResult(Result.Success(string.Empty));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extract `TargetFramework` and `TargetFrameworks` from MSBuild metadata
- resolve the Android target framework dynamically instead of assuming `net9.0-android`
- add tests covering extraction and Android package generation for non-default Android TFMs

## Validation
- `dotnet test test/DotnetDeployer.Tests/DotnetDeployer.Tests.csproj --filter AndroidTargetFrameworkTests`