### PR TITLE
fix: detect empty GitHub releases and propagate exit code on failure

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,14 +9,14 @@
     <PackageVersion Include="Serilog" Version="4.3.0" />
     <PackageVersion Include="Octokit" Version="14.*" />
     <PackageVersion Include="Zafiro" Version="45.0.5" />
-    <PackageVersion Include="DotnetPackaging" Version="10.1.0" />
-    <PackageVersion Include="DotnetPackaging.AppImage" Version="10.1.0" />
-    <PackageVersion Include="DotnetPackaging.Deb" Version="10.1.0" />
-    <PackageVersion Include="DotnetPackaging.Rpm" Version="10.1.0" />
+    <PackageVersion Include="DotnetPackaging" Version="10.1.7" />
+    <PackageVersion Include="DotnetPackaging.AppImage" Version="10.1.7" />
+    <PackageVersion Include="DotnetPackaging.Deb" Version="10.1.7" />
+    <PackageVersion Include="DotnetPackaging.Rpm" Version="10.1.7" />
     <PackageVersion Include="DotnetPackaging.Flatpak" Version="9.0.6" />
-    <PackageVersion Include="DotnetPackaging.Dmg" Version="10.1.0" />
-    <PackageVersion Include="DotnetPackaging.Exe" Version="10.1.0" />
-    <PackageVersion Include="DotnetPackaging.Msix" Version="10.1.0" />
+    <PackageVersion Include="DotnetPackaging.Dmg" Version="10.1.7" />
+    <PackageVersion Include="DotnetPackaging.Exe" Version="10.1.7" />
+    <PackageVersion Include="DotnetPackaging.Msix" Version="10.1.7" />
     <PackageVersion Include="System.CommandLine" Version="2.0.2" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.*" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />

--- a/src/DotnetDeployer.Tool/Program.cs
+++ b/src/DotnetDeployer.Tool/Program.cs
@@ -36,6 +36,8 @@ public static class Program
         rootCommand.Add(dryRunOption);
         rootCommand.Add(versionOption);
 
+        var exitCode = 0;
+
         rootCommand.SetAction(async (ParseResult parseResult) =>
         {
             var config = parseResult.GetValue(configOption) ?? new FileInfo("deployer.yaml");
@@ -54,13 +56,14 @@ public static class Program
             if (result.IsFailure)
             {
                 Log.Logger.Error("Deployment failed: {Error}", result.Error);
-                Environment.ExitCode = 1;
+                exitCode = 1;
             }
         });
 
         try
         {
-            return await rootCommand.Parse(args).InvokeAsync();
+            var parseExitCode = await rootCommand.Parse(args).InvokeAsync();
+            return parseExitCode != 0 ? parseExitCode : exitCode;
         }
         finally
         {

--- a/src/DotnetDeployer/Deployment/GitHubReleaseDeployer.cs
+++ b/src/DotnetDeployer/Deployment/GitHubReleaseDeployer.cs
@@ -65,43 +65,74 @@ public class GitHubReleaseDeployer : IGitHubReleaseDeployer
             var release = await client.Repository.Release.Create(config.Owner, config.Repo, releaseRequest);
             logger.Information("Created release: {Url}", release.HtmlUrl);
 
-            // Upload packages as they are generated
-            await foreach (var package in packages)
+            // Upload packages as they are generated, tracking count for validation
+            var uploadedCount = 0;
+
+            try
             {
-                try
+                await foreach (var package in packages)
                 {
-                    logger.Information("Uploading {FileName}...", package.FileName);
-
-                    // Read content using the byte source's observable
-                    using var ms = new MemoryStream();
-                    var tcs = new TaskCompletionSource<bool>();
-
-                    package.Content.Bytes.Subscribe(
-                        chunk => ms.Write(chunk, 0, chunk.Length),
-                        ex => tcs.TrySetException(ex),
-                        () => tcs.TrySetResult(true));
-
-                    await tcs.Task;
-                    ms.Position = 0;
-
-                    var assetUpload = new ReleaseAssetUpload
+                    try
                     {
-                        FileName = package.FileName,
-                        ContentType = GetContentType(package.Type),
-                        RawData = ms
-                    };
+                        logger.Information("Uploading {FileName}...", package.FileName);
 
-                    var asset = await client.Repository.Release.UploadAsset(release, assetUpload);
-                    logger.Information("Uploaded {FileName}: {Url}", package.FileName, asset.BrowserDownloadUrl);
-                }
-                finally
-                {
-                    package.Dispose();
+                        // Read content using the byte source's observable
+                        using var ms = new MemoryStream();
+                        var tcs = new TaskCompletionSource<bool>();
+
+                        package.Content.Bytes.Subscribe(
+                            chunk => ms.Write(chunk, 0, chunk.Length),
+                            ex => tcs.TrySetException(ex),
+                            () => tcs.TrySetResult(true));
+
+                        await tcs.Task;
+                        ms.Position = 0;
+
+                        var assetUpload = new ReleaseAssetUpload
+                        {
+                            FileName = package.FileName,
+                            ContentType = GetContentType(package.Type),
+                            RawData = ms
+                        };
+
+                        var asset = await client.Repository.Release.UploadAsset(release, assetUpload);
+                        uploadedCount++;
+                        logger.Information("Uploaded {FileName}: {Url}", package.FileName, asset.BrowserDownloadUrl);
+                    }
+                    finally
+                    {
+                        package.Dispose();
+                    }
                 }
             }
+            catch (Exception)
+            {
+                await DeleteReleaseSafely(client, config, release, logger);
+                throw;
+            }
 
-            logger.Information("GitHub release completed: {Url}", release.HtmlUrl);
+            if (uploadedCount == 0)
+            {
+                await DeleteReleaseSafely(client, config, release, logger);
+                throw new InvalidOperationException("All package generations failed. No assets were uploaded. The empty release has been deleted.");
+            }
+
+            logger.Information("GitHub release completed: {Url} ({Count} asset(s) uploaded)", release.HtmlUrl, uploadedCount);
         });
+    }
+
+    private static async Task DeleteReleaseSafely(GitHubClient client, GitHubConfig config, Release release, ILogger logger)
+    {
+        try
+        {
+            logger.Warning("Deleting empty release {Tag}...", release.TagName);
+            await client.Repository.Release.Delete(config.Owner, config.Repo, release.Id);
+            logger.Information("Deleted release {Tag}", release.TagName);
+        }
+        catch (Exception ex)
+        {
+            logger.Error(ex, "Failed to delete empty release {Tag}. Please delete it manually.", release.TagName);
+        }
     }
 
     private static string GetContentType(DeployerPackageType type) => type switch


### PR DESCRIPTION
## Problem

When all package builds fail during deployment:
1. A GitHub release is created **before** packages are built (streaming pattern)
2. All `dotnet publish` calls fail → zero assets uploaded
3. The release is left **empty** on GitHub
4. Despite `ERR` logs, the **build exits green** (exit code 0)

Observed in: https://dev.azure.com/SuperJMN/88d017bf-8396-48de-9ec0-5b2830775fca/_apis/build/builds/6448/logs/8

## Root Causes

### Empty release (`GitHubReleaseDeployer.cs`)
`GeneratePackages()` logs and skips individual build failures. If all generators fail, `await foreach` yields zero items and completes normally → `Result.Success`. The release sits empty on GitHub.

### Green build (`Program.cs`)
`SetAction(async (ParseResult) => {...})` is `Func<ParseResult, Task>` (void-returning). `InvokeAsync()` always returns `0`, overriding `Environment.ExitCode = 1`.

## Fixes

### `GitHubReleaseDeployer.cs`
- Track `uploadedCount` during asset uploads
- If `uploadedCount == 0` after the loop → delete the release and return failure
- If an exception occurs during upload → delete the release before re-throwing
- `DeleteReleaseSafely` handles cleanup errors gracefully

### `Program.cs`
- Use a closure variable to capture the exit code from the handler
- Return it from `Main` instead of relying on `Environment.ExitCode`