### PR TITLE
Fix FindWwwroot to prefer publish/wwwroot over intermediate wwwroot

### DIFF
--- a/src/DotnetDeployer/Deployment/GitHubPagesDeployer.cs
+++ b/src/DotnetDeployer/Deployment/GitHubPagesDeployer.cs
@@ -175,35 +175,17 @@ public class GitHubPagesDeployer : IGitHubPagesDeployer
 
     private static string? FindWwwroot(string projectDir)
     {
-        // Common locations for wwwroot after publish
-        var searchPaths = new[]
-        {
-            IOPath.Combine(projectDir, "bin", "Release", "net9.0-browser", "publish", "wwwroot"),
-            IOPath.Combine(projectDir, "bin", "Release", "net8.0-browser", "publish", "wwwroot"),
-            IOPath.Combine(projectDir, "bin", "Release", "net9.0-browser", "wwwroot"),
-            IOPath.Combine(projectDir, "bin", "Release", "net8.0-browser", "wwwroot"),
-        };
-
-        foreach (var path in searchPaths)
-        {
-            if (Directory.Exists(path))
-            {
-                return path;
-            }
-        }
-
-        // Try to find any wwwroot directory in bin/Release
         var releaseDir = IOPath.Combine(projectDir, "bin", "Release");
-        if (Directory.Exists(releaseDir))
+        if (!Directory.Exists(releaseDir))
         {
-            var wwwroots = Directory.GetDirectories(releaseDir, "wwwroot", SearchOption.AllDirectories);
-            if (wwwroots.Length > 0)
-            {
-                return wwwroots[0];
-            }
+            return null;
         }
 
-        return null;
+        // Search all wwwroot directories, preferring those under a "publish" folder
+        var wwwroots = Directory.GetDirectories(releaseDir, "wwwroot", SearchOption.AllDirectories);
+        return wwwroots
+            .OrderByDescending(p => p.Contains(IOPath.DirectorySeparatorChar + "publish" + IOPath.DirectorySeparatorChar))
+            .FirstOrDefault();
     }
 
     private static void CopyDirectory(string sourceDir, string destDir)


### PR DESCRIPTION
The `FindWwwroot` method had hardcoded TFM paths (`net8.0-browser`, `net9.0-browser`) that missed `net10.0-browser` and any future TFMs. The recursive fallback found the intermediate build `wwwroot` (which only contains `_framework`) instead of `publish/wwwroot` (which has the complete site).

Replace with a single generic recursive search that prefers paths containing `/publish/`.