### PR TITLE
feat: embed deployer-computed version in published assemblies

### DIFF
--- a/src/DotnetDeployer/Packaging/Android/AndroidVersionHelper.cs
+++ b/src/DotnetDeployer/Packaging/Android/AndroidVersionHelper.cs
@@ -6,6 +6,9 @@ public static class AndroidVersionHelper
     /// Builds MSBuild arguments to set Android version properties from a semantic version string.
     /// ApplicationDisplayVersion maps to android:versionName (e.g. "1.9.26").
     /// ApplicationVersion maps to android:versionCode (integer, e.g. 10926).
+    /// Version propagates into the managed assembly (AssemblyVersion / FileVersion /
+    /// InformationalVersion via MSBuild's default derivation) so the running app can
+    /// report the same version Deployer published.
     /// </summary>
     public static string GetVersionArgs(string? version)
     {
@@ -15,7 +18,7 @@ public static class AndroidVersionHelper
         }
 
         var versionCode = ToVersionCode(version);
-        return $"-p:ApplicationDisplayVersion={version} -p:ApplicationVersion={versionCode}";
+        return $"-p:Version={version} -p:ApplicationDisplayVersion={version} -p:ApplicationVersion={versionCode}";
     }
 
     /// <summary>

--- a/src/DotnetDeployer/Packaging/Linux/AppImageGenerator.cs
+++ b/src/DotnetDeployer/Packaging/Linux/AppImageGenerator.cs
@@ -1,6 +1,7 @@
 using CSharpFunctionalExtensions;
 using DotnetDeployer.Domain;
 using DotnetDeployer.Msbuild;
+using DotnetDeployer.Versioning;
 using DotnetPackaging.AppImage;
 using Serilog;
 using Zafiro.DivineBytes;
@@ -45,6 +46,7 @@ public class AppImageGenerator : IPackageGenerator
                 pub.SelfContained = true;
                 pub.Configuration = "Release";
                 pub.Rid = arch.ToLinuxRid();
+                pub.MsBuildProperties = PublishVersionProperties.For(metadata.Version);
             },
             logger);
 

--- a/src/DotnetDeployer/Packaging/Linux/DebGenerator.cs
+++ b/src/DotnetDeployer/Packaging/Linux/DebGenerator.cs
@@ -1,6 +1,7 @@
 using CSharpFunctionalExtensions;
 using DotnetDeployer.Domain;
 using DotnetDeployer.Msbuild;
+using DotnetDeployer.Versioning;
 using DotnetPackaging.Deb;
 using Serilog;
 using Zafiro.DivineBytes;
@@ -45,6 +46,7 @@ public class DebGenerator : IPackageGenerator
                 pub.SelfContained = true;
                 pub.Configuration = "Release";
                 pub.Rid = arch.ToLinuxRid();
+                pub.MsBuildProperties = PublishVersionProperties.For(metadata.Version);
             },
             logger);
 

--- a/src/DotnetDeployer/Packaging/Linux/FlatpakGenerator.cs
+++ b/src/DotnetDeployer/Packaging/Linux/FlatpakGenerator.cs
@@ -1,6 +1,7 @@
 using CSharpFunctionalExtensions;
 using DotnetDeployer.Domain;
 using DotnetDeployer.Msbuild;
+using DotnetDeployer.Versioning;
 using DotnetPackaging.Flatpak;
 using Serilog;
 using Zafiro.DivineBytes;
@@ -45,6 +46,7 @@ public class FlatpakGenerator : IPackageGenerator
                 pub.SelfContained = true;
                 pub.Configuration = "Release";
                 pub.Rid = arch.ToLinuxRid();
+                pub.MsBuildProperties = PublishVersionProperties.For(metadata.Version);
             },
             logger);
 

--- a/src/DotnetDeployer/Packaging/Linux/RpmGenerator.cs
+++ b/src/DotnetDeployer/Packaging/Linux/RpmGenerator.cs
@@ -1,6 +1,7 @@
 using CSharpFunctionalExtensions;
 using DotnetDeployer.Domain;
 using DotnetDeployer.Msbuild;
+using DotnetDeployer.Versioning;
 using DotnetPackaging.Rpm;
 using Serilog;
 using Zafiro.DivineBytes;
@@ -45,6 +46,7 @@ public class RpmGenerator : IPackageGenerator
                 pub.SelfContained = true;
                 pub.Configuration = "Release";
                 pub.Rid = arch.ToLinuxRid();
+                pub.MsBuildProperties = PublishVersionProperties.For(metadata.Version);
             },
             logger);
 

--- a/src/DotnetDeployer/Packaging/Mac/DmgGenerator.cs
+++ b/src/DotnetDeployer/Packaging/Mac/DmgGenerator.cs
@@ -1,6 +1,7 @@
 using CSharpFunctionalExtensions;
 using DotnetDeployer.Domain;
 using DotnetDeployer.Msbuild;
+using DotnetDeployer.Versioning;
 using DotnetPackaging.Dmg;
 using Serilog;
 using Zafiro.DivineBytes;
@@ -44,6 +45,7 @@ public class DmgGenerator : IPackageGenerator
                 pub.Configuration = "Release";
                 pub.SingleFile = true;
                 pub.Rid = arch.ToMacRid();
+                pub.MsBuildProperties = PublishVersionProperties.For(metadata.Version);
             },
             logger);
 

--- a/src/DotnetDeployer/Packaging/Windows/ExeSetupGenerator.cs
+++ b/src/DotnetDeployer/Packaging/Windows/ExeSetupGenerator.cs
@@ -1,6 +1,7 @@
 using CSharpFunctionalExtensions;
 using DotnetDeployer.Domain;
 using DotnetDeployer.Msbuild;
+using DotnetDeployer.Versioning;
 using DotnetPackaging.Exe;
 using Serilog;
 using Zafiro.DivineBytes;
@@ -46,6 +47,7 @@ public class ExeSetupGenerator : IPackageGenerator
                 pub.SelfContained = true;
                 pub.Configuration = "Release";
                 pub.Rid = arch.ToWindowsRid();
+                pub.MsBuildProperties = PublishVersionProperties.For(metadata.Version);
             },
             logger);
 

--- a/src/DotnetDeployer/Packaging/Windows/ExeSfxGenerator.cs
+++ b/src/DotnetDeployer/Packaging/Windows/ExeSfxGenerator.cs
@@ -1,6 +1,7 @@
 using CSharpFunctionalExtensions;
 using DotnetDeployer.Domain;
 using DotnetDeployer.Msbuild;
+using DotnetDeployer.Versioning;
 using DotnetPackaging.Exe;
 using Serilog;
 using Zafiro.DivineBytes;
@@ -45,6 +46,7 @@ public class ExeSfxGenerator : IPackageGenerator
                 pub.SelfContained = true;
                 pub.Configuration = "Release";
                 pub.Rid = arch.ToWindowsRid();
+                pub.MsBuildProperties = PublishVersionProperties.For(metadata.Version);
             },
             logger);
 

--- a/src/DotnetDeployer/Packaging/Windows/MsixGenerator.cs
+++ b/src/DotnetDeployer/Packaging/Windows/MsixGenerator.cs
@@ -1,6 +1,7 @@
 using CSharpFunctionalExtensions;
 using DotnetDeployer.Domain;
 using DotnetDeployer.Msbuild;
+using DotnetDeployer.Versioning;
 using DotnetPackaging.Msix;
 using Serilog;
 using Zafiro.DivineBytes;
@@ -37,6 +38,7 @@ public class MsixGenerator : IPackageGenerator
                 pub.SelfContained = false; // MSIX usually framework-dependent
                 pub.Configuration = "Release";
                 pub.Rid = arch.ToWindowsRid();
+                pub.MsBuildProperties = PublishVersionProperties.For(metadata.Version);
             },
             logger);
 

--- a/src/DotnetDeployer/Versioning/PublishVersionProperties.cs
+++ b/src/DotnetDeployer/Versioning/PublishVersionProperties.cs
@@ -1,0 +1,23 @@
+namespace DotnetDeployer.Versioning;
+
+/// <summary>
+/// Builds the MSBuild property dictionary that propagates the deployer-computed
+/// version into the underlying <c>dotnet publish</c> invocation so the resulting
+/// assembly is stamped with matching AssemblyVersion / FileVersion /
+/// InformationalVersion (MSBuild derives all three from <c>Version</c>).
+/// </summary>
+public static class PublishVersionProperties
+{
+    public static IReadOnlyDictionary<string, string>? For(string? version)
+    {
+        if (string.IsNullOrWhiteSpace(version))
+        {
+            return null;
+        }
+
+        return new Dictionary<string, string>
+        {
+            ["Version"] = version
+        };
+    }
+}

--- a/test/DotnetDeployer.Tests/Platforms/Android/AndroidVersionHelperTests.cs
+++ b/test/DotnetDeployer.Tests/Platforms/Android/AndroidVersionHelperTests.cs
@@ -1,0 +1,37 @@
+using DotnetDeployer.Packaging.Android;
+
+namespace DotnetDeployer.Tests.Platforms.Android;
+
+public class AndroidVersionHelperTests
+{
+    [Fact]
+    public void GetVersionArgs_NullOrEmpty_ReturnsEmpty()
+    {
+        Assert.Equal("", AndroidVersionHelper.GetVersionArgs(null));
+        Assert.Equal("", AndroidVersionHelper.GetVersionArgs(""));
+        Assert.Equal("", AndroidVersionHelper.GetVersionArgs("   "));
+    }
+
+    [Fact]
+    public void GetVersionArgs_Version_IncludesManagedVersionProperty()
+    {
+        var args = AndroidVersionHelper.GetVersionArgs("1.9.27");
+
+        // Must stamp the managed assembly (AssemblyVersion / FileVersion /
+        // InformationalVersion are derived from Version by MSBuild).
+        Assert.Contains("-p:Version=1.9.27", args);
+        // Must keep producing the Android-manifest properties.
+        Assert.Contains("-p:ApplicationDisplayVersion=1.9.27", args);
+        Assert.Contains($"-p:ApplicationVersion={AndroidVersionHelper.ToVersionCode("1.9.27")}", args);
+    }
+
+    [Theory]
+    [InlineData("1.0.0", 10000)]
+    [InlineData("1.9.26", 10926)]
+    [InlineData("2.3.45", 20345)]
+    [InlineData("0.0.1", 1)]
+    public void ToVersionCode_ComputesExpectedInteger(string version, int expected)
+    {
+        Assert.Equal(expected, AndroidVersionHelper.ToVersionCode(version));
+    }
+}

--- a/test/DotnetDeployer.Tests/Versioning/PublishVersionPropertiesTests.cs
+++ b/test/DotnetDeployer.Tests/Versioning/PublishVersionPropertiesTests.cs
@@ -1,0 +1,33 @@
+using DotnetDeployer.Versioning;
+
+namespace DotnetDeployer.Tests.Versioning;
+
+public class PublishVersionPropertiesTests
+{
+    [Fact]
+    public void For_Null_ReturnsNull()
+    {
+        Assert.Null(PublishVersionProperties.For(null));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void For_EmptyOrWhitespace_ReturnsNull(string version)
+    {
+        Assert.Null(PublishVersionProperties.For(version));
+    }
+
+    [Theory]
+    [InlineData("1.2.3")]
+    [InlineData("1.9.27-alpha.3")]
+    [InlineData("0.0.1+build.42")]
+    public void For_ValidVersion_ReturnsDictionaryWithVersion(string version)
+    {
+        var props = PublishVersionProperties.For(version);
+
+        Assert.NotNull(props);
+        Assert.Single(props!);
+        Assert.Equal(version, props!["Version"]);
+    }
+}


### PR DESCRIPTION
## Problema

La versión calculada por GitVersion llegaba a los metadatos de paquete (AppImage/Deb/APK `versionName`, etc.) y a `dotnet pack`, pero **no** al `dotnet publish` del binario. Como consecuencia, `AssemblyVersion` / `InformationalVersion` del ejecutable publicado quedaban en `1.0.0` (valor por defecto del csproj), desalineados con la versión real de release.

## Cambios

- **`Versioning/PublishVersionProperties.cs`** (nuevo) — helper que devuelve `{ "Version" = <v> }` o `null` si no hay versión.
- **Generadores desktop** (AppImage, Deb, Rpm, Flatpak, ExeSetup, ExeSfx, Msix, Dmg): asignan `pub.MsBuildProperties = PublishVersionProperties.For(metadata.Version)` en el callback de publish, así MSBuild estampa `AssemblyVersion` / `FileVersion` / `InformationalVersion`.
- **`AndroidVersionHelper.GetVersionArgs`**: emite `-p:Version=<v>` junto a los ya existentes `ApplicationDisplayVersion` / `ApplicationVersion` (APK + AAB).
- Tests unitarios para ambos helpers.

## Resultado

En runtime la app publicada puede leer su versión real:

```csharp
Assembly.GetExecutingAssembly()
        .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
```

## Verificación

- `dotnet build` ✅
- `dotnet test` → 93/93 ✅