### PR TITLE
Enable Android publish on Linux/arm64 via shim overlay (#60)

### DIFF
--- a/docs/android-on-non-x64-linux.md
+++ b/docs/android-on-non-x64-linux.md
@@ -1,6 +1,6 @@
 # Android publish on non-x64 Linux
 
-**Status: blocked / TODO.** Tracking a clean resolution rather than shipping a brittle workaround.
+**Status: works via shim overlay on Linux/arm64.** Other non-x64 Linux architectures (armhf, riscv64…) remain unsupported.
 
 ## What does and doesn't work today
 
@@ -9,37 +9,31 @@
 | Linux x86_64 | Works natively |
 | Windows x86_64 | Works natively |
 | macOS (Intel + Apple Silicon) | Works natively |
-| **Linux arm64** (Raspberry Pi, Ampere/Graviton, Linux VMs on Apple Silicon) | **Fails fast** with a clear error from `AndroidPublishExecutor` |
+| **Linux arm64** (Raspberry Pi, Ampere/Graviton, Linux VMs on Apple Silicon) | **Works via shim overlay** (see below) |
+| Linux on any other non-x64 architecture | Fails — no shim available |
 
-If a Fleet worker on Linux/arm64 picks up an Android-targeted job, DotnetDeployer aborts that target with a message pointing at the two tracking issues (see below). Other targets (desktop deb, Windows setup exe, NuGet packages) for the same project are unaffected and continue to publish.
+When a Fleet worker on Linux/arm64 picks up an Android-targeted job, `AndroidPrerequisitesInstaller` invokes the bootstrap script from [`SuperJMN/DotnetAndroidArm64Shims`](https://github.com/SuperJMN/DotnetAndroidArm64Shims) once per process, before doing anything else. The script is idempotent: it scans `~/.dotnet/packs/Microsoft.Android.Sdk.Linux/`, downloads the release tarball matching each installed pack version, verifies SHA256 sums, backs up the originals, and overlays the arm64 builds. Re-runs are no-ops.
 
-## Why we can't just route through a container
+After the overlay, the rest of the publish pipeline (JDK/SDK provisioning, `dotnet publish`, signing) runs unmodified. Validated on a Raspberry Pi 4 with a vanilla `dotnet new android` template against shim release `36.1.53`: signed APK in ~3m40s, installed and launched on a real Pixel device.
+
+If the installed `Microsoft.Android.Sdk.Linux` pack version has no matching shim release, `EnsureAsync()` returns an actionable failure pointing at <https://github.com/SuperJMN/DotnetAndroidArm64Shims/releases>. Other targets in the same project (NuGet, deb, etc.) keep deploying.
+
+## Why we don't route through a container (post-mortem)
 
 The first instinct is "spin up a `linux/amd64` container with `qemu-user-static`, run `dotnet publish` inside, mount the result back". Tried it; doesn't work.
 
 `qemu-user` emulating amd64 on aarch64 cannot run the .NET runtime reliably. Even a trivial `dotnet new console` segfaults inside `mcr.microsoft.com/dotnet/sdk:10.0` under `linux/amd64`. The PLINQ ETW provider initialization throws on startup; threading-heavy paths abort with SIGSEGV. Confirmed empirically with both Debian's qemu-user-static 5.2 and `tonistiigi/binfmt`'s qemu 9.x, on a Raspberry Pi 4 running Raspberry Pi OS 64-bit (kernel 6.x).
 
-This isn't something a flag fixes — the .NET runtime makes assumptions about signal handling and futex semantics that qemu-user doesn't honour. It's a known class of bugs in the dotnet/runtime tracker.
+This isn't something a flag fixes — the .NET runtime makes assumptions about signal handling and futex semantics that qemu-user doesn't honour. It's a known class of bugs in the dotnet/runtime tracker. Kept here as historical context for "why we don't containerize".
 
-## Why we can't just patch the SDK pack on disk
+## Why we don't reimplement the overlay in C#
 
-The `Microsoft.Android.Sdk.Linux` workload pack ships these binaries as **x86_64 ELFs only** — they're invoked from MSBuild tasks running inside the native arm64 dotnet process, so they have to be replaceable with arm64 builds:
+We deliberately invoke `install-shims.sh` over `curl | bash` instead of downloading the tarball directly from C#:
 
-- `tools/Linux/aapt2`
-- `tools/libMono.Unix.so`
-- `tools/libZipSharpNative-3-3.so`
-- `tools/Linux/binutils/bin/{as,ld,llc,llvm-mc,llvm-objcopy,llvm-strip}` and friends (only needed for AOT)
+- The bootstrap script is the **stable contract**. Its internals (release discovery, SHA256 verification, pack-version → tarball mapping, backup of originals) will evolve.
+- Keeping the overlay logic in the shim repo lets it ship its own release cadence, CI and tests, separate from DotnetDeployer.
+- `aapt2` has strict version-match against the pack (`error XA0111: Unsupported version of AAPT2`), and Microsoft bumps it on a roughly monthly cadence. Centralising the version-matrix logic in one place avoids drift.
 
-We *could* build arm64 replacements ourselves and overlay them onto the pack. That's a real project — see [`SuperJMN/DotnetAndroidArm64Shims`](https://github.com/SuperJMN/DotnetAndroidArm64Shims). It's deliberately kept out of DotnetDeployer because:
+## How this gets fully resolved upstream
 
-- The maintenance burden is non-trivial (`aapt2` has strict version-match against the pack, and Microsoft bumps it monthly — `error XA0111: Unsupported version of AAPT2`).
-- It deserves its own release cadence, CI, and test surface separate from the deployer.
-
-## How this gets unblocked
-
-Either of these closes the gap:
-
-1. **Upstream provides linux-arm64 builds.** Asked here: <https://github.com/dotnet/android/issues/11184>. If accepted, the pack just works on arm64 and we delete the short-circuit in `AndroidPublishExecutor`.
-2. **`DotnetAndroidArm64Shims` ships v1.** Then DotnetDeployer's `AndroidPrerequisitesInstaller` invokes its bootstrap to overlay the shim binaries before publish, and `AndroidPublishExecutor` lets the publish proceed natively.
-
-Whichever lands first wins. Until then: clear failure with actionable links, no silent fallbacks, no half-working containerized path.
+If Microsoft ships a linux-arm64 host build of `Microsoft.Android.Sdk.Linux`, the shim overlay becomes redundant: the bootstrap script's release set goes empty and the call becomes a true no-op, with no changes needed in DotnetDeployer. Tracked upstream in <https://github.com/dotnet/android/issues/11184>.

--- a/src/DotnetDeployer/DotnetDeployer.csproj
+++ b/src/DotnetDeployer/DotnetDeployer.csproj
@@ -26,4 +26,8 @@
     <PackageReference Include="DotnetPackaging.Msix" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="DotnetDeployer.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/DotnetDeployer/Packaging/Android/AndroidArm64ShimInstaller.cs
+++ b/src/DotnetDeployer/Packaging/Android/AndroidArm64ShimInstaller.cs
@@ -1,0 +1,119 @@
+using System.Runtime.InteropServices;
+using CSharpFunctionalExtensions;
+using Serilog;
+using Zafiro.Commands;
+using ICommand = Zafiro.Commands.ICommand;
+
+namespace DotnetDeployer.Packaging.Android;
+
+/// <summary>
+/// Overlays linux-arm64 builds of <c>aapt2</c>, <c>libMono.Unix.so</c> and
+/// <c>libZipSharpNative-3-3.so</c> onto every installed
+/// <c>Microsoft.Android.Sdk.Linux</c> pack on the current machine, using the
+/// bootstrap script from
+/// <see href="https://github.com/SuperJMN/DotnetAndroidArm64Shims"/>.
+/// <para>
+/// No-op on hosts where <see cref="IsApplicable"/> is <c>false</c>
+/// (anything that is not Linux/arm64).
+/// </para>
+/// <para>
+/// The bootstrap script is the stable contract — its internals (release
+/// discovery, SHA256 verification, backup of originals) will evolve. We
+/// deliberately don't reimplement that in C#.
+/// </para>
+/// </summary>
+public sealed class AndroidArm64ShimInstaller
+{
+    private const string BootstrapUrl =
+        "https://raw.githubusercontent.com/SuperJMN/DotnetAndroidArm64Shims/main/scripts/install-shims.sh";
+
+    private static readonly SemaphoreSlim Gate = new(1, 1);
+    private static bool alreadyInstalled;
+
+    private readonly ICommand command;
+    private readonly ILogger logger;
+
+    public AndroidArm64ShimInstaller(ICommand? command, ILogger logger)
+    {
+        this.command = command ?? new Command(Maybe<ILogger>.None);
+        this.logger = logger;
+    }
+
+    /// <summary>
+    /// True when the current host needs the arm64 shim overlay to publish
+    /// Android targets — i.e. Linux on arm64.
+    /// </summary>
+    public static bool IsApplicable { get; } =
+        RuntimeInformation.IsOSPlatform(OSPlatform.Linux) &&
+        RuntimeInformation.OSArchitecture == Architecture.Arm64;
+
+    /// <summary>
+    /// Idempotently overlays the arm64 shims onto every installed
+    /// <c>Microsoft.Android.Sdk.Linux</c> pack. Memoized: at most one
+    /// successful install per process, regardless of how many Android
+    /// targets the orchestrator iterates over.
+    /// </summary>
+    public async Task<Result> EnsureAsync()
+    {
+        if (!IsApplicable)
+        {
+            return Result.Success();
+        }
+
+        await Gate.WaitAsync();
+        try
+        {
+            if (alreadyInstalled)
+            {
+                return Result.Success();
+            }
+
+            logger.Information(
+                "Installing linux-arm64 Android SDK shims from SuperJMN/DotnetAndroidArm64Shims");
+
+            // The script is idempotent. Piping curl into bash keeps the
+            // contract zero-deps for consumers (curl + bash are universally
+            // present on Linux). `set -o pipefail` ensures a failed curl
+            // surfaces as a non-zero exit instead of being masked by bash's
+            // exit code.
+            var result = await command.Execute(
+                "bash",
+                $"-c \"set -o pipefail; curl -fsSL {BootstrapUrl} | bash\"",
+                Environment.CurrentDirectory);
+
+            if (result.IsFailure)
+            {
+                return Result.Failure(UnavailableShimMessage(result.Error));
+            }
+
+            alreadyInstalled = true;
+            return Result.Success();
+        }
+        finally
+        {
+            Gate.Release();
+        }
+    }
+
+    internal static string UnavailableShimMessage(string? underlyingError) =>
+        "Failed to install linux-arm64 Android SDK shims. " +
+        "If your installed Microsoft.Android.Sdk.Linux pack version has no " +
+        "matching shim release at " +
+        "https://github.com/SuperJMN/DotnetAndroidArm64Shims/releases, " +
+        "open an issue there asking for a build of that version. " +
+        $"Underlying error: {underlyingError}";
+
+    // Test hook only.
+    internal static void ResetForTests()
+    {
+        Gate.Wait();
+        try
+        {
+            alreadyInstalled = false;
+        }
+        finally
+        {
+            Gate.Release();
+        }
+    }
+}

--- a/src/DotnetDeployer/Packaging/Android/AndroidPrerequisitesInstaller.cs
+++ b/src/DotnetDeployer/Packaging/Android/AndroidPrerequisitesInstaller.cs
@@ -48,18 +48,15 @@ public class AndroidPrerequisitesInstaller
     /// MSBuild property lookups.</param>
     public async Task<Result> Ensure(string anyAndroidProject, ILogger logger)
     {
-        // On non-x64 Linux hosts the Android publish currently fails fast
-        // with a clear error in AndroidPublishExecutor (the workload pack's
-        // host helpers are x86_64-only). Skip host-side JDK/SDK provisioning
-        // here so the failure surfaces from a single, well-documented place.
-        // See docs/android-on-non-x64-linux.md.
-        if (AndroidPublishExecutor.IsHostUnsupported)
+        // On Linux/arm64 hosts, overlay arm64 shims onto every installed
+        // Microsoft.Android.Sdk.Linux pack before doing anything else. The
+        // workload pack ships aapt2/libMono.Unix.so/libZipSharpNative as
+        // x86_64-only and the overlay lets the rest of the publish pipeline
+        // run unmodified. No-op on x64 hosts.
+        var shimResult = await new AndroidArm64ShimInstaller(command, logger).EnsureAsync();
+        if (shimResult.IsFailure)
         {
-            logger.Warning(
-                "Host is Linux/{Arch} — Android publish is not supported here; skipping host-side JDK/SDK provisioning. " +
-                "The publish step will fail with a clear error.",
-                System.Runtime.InteropServices.RuntimeInformation.OSArchitecture);
-            return Result.Success();
+            return shimResult;
         }
 
         var sdkDir = ResolveSdkDir();

--- a/src/DotnetDeployer/Packaging/Android/AndroidPublishExecutor.cs
+++ b/src/DotnetDeployer/Packaging/Android/AndroidPublishExecutor.cs
@@ -8,27 +8,18 @@ namespace DotnetDeployer.Packaging.Android;
 
 /// <summary>
 /// Routes <c>dotnet publish</c> for Android targets through the host's native
-/// SDK on x86_64 Linux/macOS/Windows. On non-x86_64 Linux hosts (Raspberry Pi,
-/// Apple Silicon Linux VMs, Ampere/Graviton CI runners…) the build is currently
-/// blocked because the <c>Microsoft.Android.Sdk.Linux</c> workload pack ships
-/// host binaries (<c>aapt2</c>, <c>libMono.Unix.so</c>,
-/// <c>libZipSharpNative-3-3.so</c>, the LLVM/binutils bundle) as x86_64 ELFs
-/// only.
-///
-/// TODO: lift this restriction once one of the following lands:
-///   • Microsoft publishes a linux-arm64 host build of
-///     <c>Microsoft.Android.Sdk.Linux</c>. Tracked upstream in
-///     https://github.com/dotnet/android/issues/11184.
-///   • The shim project at
-///     https://github.com/SuperJMN/DotnetAndroidArm64Shims is consumable
-///     end-to-end (provides arm64 builds of the missing host binaries plus a
-///     bootstrap that overlays them onto the installed pack).
+/// SDK. On Linux/arm64 hosts (Raspberry Pi, Apple Silicon Linux VMs,
+/// Ampere/Graviton CI runners…) the <c>Microsoft.Android.Sdk.Linux</c>
+/// workload pack ships some host binaries (<c>aapt2</c>,
+/// <c>libMono.Unix.so</c>, <c>libZipSharpNative-3-3.so</c>) as x86_64 ELFs
+/// only; arm64 replacements are overlaid by
+/// <see cref="AndroidArm64ShimInstaller"/>, invoked from
+/// <c>AndroidPrerequisitesInstaller</c> before publish.
 ///
 /// We deliberately do NOT route through a linux/amd64 container. qemu-user
 /// emulating amd64 on aarch64 cannot run the .NET runtime reliably (PLINQ ETW
 /// init failure and segfaults on plain <c>dotnet new console</c>, confirmed
-/// against qemu 5.2 and qemu 9.x), so containerization is a dead end until
-/// upstream changes.
+/// against qemu 5.2 and qemu 9.x), so containerization is a dead end.
 /// </summary>
 public sealed class AndroidPublishExecutor
 {
@@ -42,20 +33,21 @@ public sealed class AndroidPublishExecutor
     }
 
     /// <summary>
-    /// True when this host cannot currently run <c>dotnet publish</c> for
-    /// Android — i.e. Linux on a non-x86_64 architecture.
+    /// True when this host runs <c>dotnet publish</c> for Android directly
+    /// against the workload pack with no overlay (Windows, macOS, Linux/x64).
     /// </summary>
-    public static bool IsHostUnsupported { get; } =
-        RuntimeInformation.IsOSPlatform(OSPlatform.Linux) &&
-        RuntimeInformation.OSArchitecture != Architecture.X64;
+    public static bool IsHostNativelySupported { get; } =
+        !RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ||
+        RuntimeInformation.OSArchitecture == Architecture.X64;
+
+    /// <summary>
+    /// True when this host needs <see cref="AndroidArm64ShimInstaller"/> to
+    /// patch the workload pack before publish — i.e. Linux/arm64.
+    /// </summary>
+    public static bool IsHostShimmable => AndroidArm64ShimInstaller.IsApplicable;
 
     public async Task<Result> Publish(string projectPath, string publishArgs, string workingDirectory)
     {
-        if (IsHostUnsupported)
-        {
-            return Result.Failure(UnsupportedHostMessage());
-        }
-
         var arguments = $"publish \"{projectPath}\" {publishArgs}";
 
         var native = await command.Execute("dotnet", arguments, workingDirectory);
@@ -145,11 +137,4 @@ public sealed class AndroidPublishExecutor
         return null;
     }
 
-    internal static string UnsupportedHostMessage() =>
-        $"Android publish is not supported on Linux/{RuntimeInformation.OSArchitecture} hosts: " +
-        "Microsoft.Android.Sdk.Linux ships host binaries (aapt2, libMono.Unix.so, " +
-        "libZipSharpNative-3-3.so) as x86_64 ELFs only, and qemu-user emulation of the " +
-        ".NET SDK is not reliable enough to use as a workaround. " +
-        "Tracking a clean fix in https://github.com/SuperJMN/DotnetAndroidArm64Shims " +
-        "and upstream in https://github.com/dotnet/android/issues/11184.";
 }

--- a/test/DotnetDeployer.Tests/Platforms/Android/AndroidArm64ShimInstallerTests.cs
+++ b/test/DotnetDeployer.Tests/Platforms/Android/AndroidArm64ShimInstallerTests.cs
@@ -1,0 +1,117 @@
+using System.Runtime.InteropServices;
+using CSharpFunctionalExtensions;
+using DotnetDeployer.Packaging.Android;
+using Serilog;
+using Zafiro.Commands;
+using ICommand = Zafiro.Commands.ICommand;
+
+namespace DotnetDeployer.Tests.Platforms.Android;
+
+[Collection(nameof(AndroidArm64ShimInstallerCollection))]
+public class AndroidArm64ShimInstallerTests
+{
+    [Fact]
+    public void IsApplicable_matches_linux_arm64()
+    {
+        var expected = RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+                       && RuntimeInformation.OSArchitecture == Architecture.Arm64;
+
+        Assert.Equal(expected, AndroidArm64ShimInstaller.IsApplicable);
+    }
+
+    [Fact]
+    public async Task EnsureAsync_is_a_noop_on_non_arm64_linux_hosts()
+    {
+        if (AndroidArm64ShimInstaller.IsApplicable)
+        {
+            return;
+        }
+
+        AndroidArm64ShimInstaller.ResetForTests();
+
+        var fake = new ScriptedCommand([]);
+        var installer = new AndroidArm64ShimInstaller(fake, new LoggerConfiguration().CreateLogger());
+
+        var result = await installer.EnsureAsync();
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(0, fake.Calls);
+    }
+
+    [Fact]
+    public async Task EnsureAsync_runs_bootstrap_once_then_memoizes()
+    {
+        if (!AndroidArm64ShimInstaller.IsApplicable)
+        {
+            return;
+        }
+
+        AndroidArm64ShimInstaller.ResetForTests();
+
+        var fake = new ScriptedCommand([Result.Success(string.Empty)]);
+        var installer = new AndroidArm64ShimInstaller(fake, new LoggerConfiguration().CreateLogger());
+
+        var first = await installer.EnsureAsync();
+        var second = await installer.EnsureAsync();
+
+        Assert.True(first.IsSuccess);
+        Assert.True(second.IsSuccess);
+        Assert.Equal(1, fake.Calls);
+        Assert.Equal("bash", fake.LastCommand);
+        Assert.Contains("DotnetAndroidArm64Shims", fake.LastArguments);
+        Assert.Contains("install-shims.sh", fake.LastArguments);
+    }
+
+    [Fact]
+    public async Task EnsureAsync_returns_actionable_failure_when_bootstrap_fails()
+    {
+        if (!AndroidArm64ShimInstaller.IsApplicable)
+        {
+            return;
+        }
+
+        AndroidArm64ShimInstaller.ResetForTests();
+
+        var fake = new ScriptedCommand([Result.Failure<string>("curl: (22) The requested URL returned error: 404")]);
+        var installer = new AndroidArm64ShimInstaller(fake, new LoggerConfiguration().CreateLogger());
+
+        var result = await installer.EnsureAsync();
+
+        Assert.True(result.IsFailure);
+        Assert.Contains("DotnetAndroidArm64Shims/releases", result.Error);
+        Assert.Contains("404", result.Error);
+
+        // Failed install must NOT be memoized — a retry should run bash again.
+        var fakeRetry = new ScriptedCommand([Result.Success(string.Empty)]);
+        var installerRetry = new AndroidArm64ShimInstaller(fakeRetry, new LoggerConfiguration().CreateLogger());
+        var retry = await installerRetry.EnsureAsync();
+
+        Assert.True(retry.IsSuccess);
+        Assert.Equal(1, fakeRetry.Calls);
+    }
+
+    private sealed class ScriptedCommand : ICommand
+    {
+        private readonly Queue<Result<string>> responses;
+
+        public ScriptedCommand(IEnumerable<Result<string>> responses)
+        {
+            this.responses = new Queue<Result<string>>(responses);
+        }
+
+        public int Calls { get; private set; }
+        public string? LastCommand { get; private set; }
+        public string? LastArguments { get; private set; }
+
+        public Task<Result<string>> Execute(string command, string arguments, string workingDirectory = "", Dictionary<string, string>? environmentVariables = null)
+        {
+            Calls++;
+            LastCommand = command;
+            LastArguments = arguments;
+            return Task.FromResult(responses.Dequeue());
+        }
+    }
+}
+
+[CollectionDefinition(nameof(AndroidArm64ShimInstallerCollection), DisableParallelization = true)]
+public sealed class AndroidArm64ShimInstallerCollection;

--- a/test/DotnetDeployer.Tests/Platforms/Android/AndroidPublishExecutorTests.cs
+++ b/test/DotnetDeployer.Tests/Platforms/Android/AndroidPublishExecutorTests.cs
@@ -10,24 +10,21 @@ namespace DotnetDeployer.Tests.Platforms.Android;
 public class AndroidPublishExecutorTests
 {
     [Fact]
-    public void IsHostUnsupported_matches_runtime_arch()
+    public void IsHostNativelySupported_matches_runtime_arch()
     {
-        var expected = RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
-                       && RuntimeInformation.OSArchitecture != Architecture.X64;
+        var expected = !RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+                       || RuntimeInformation.OSArchitecture == Architecture.X64;
 
-        Assert.Equal(expected, AndroidPublishExecutor.IsHostUnsupported);
+        Assert.Equal(expected, AndroidPublishExecutor.IsHostNativelySupported);
     }
 
     [Fact]
-    public void UnsupportedHostMessage_points_users_to_the_tracking_repo_and_upstream_issue()
+    public void IsHostShimmable_matches_linux_arm64()
     {
-        var msg = typeof(AndroidPublishExecutor)
-            .GetMethod("UnsupportedHostMessage", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!
-            .Invoke(null, null) as string;
+        var expected = RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+                       && RuntimeInformation.OSArchitecture == Architecture.Arm64;
 
-        Assert.NotNull(msg);
-        Assert.Contains("DotnetAndroidArm64Shims", msg);
-        Assert.Contains("dotnet/android/issues/11184", msg);
+        Assert.Equal(expected, AndroidPublishExecutor.IsHostShimmable);
     }
 
     [Theory]
@@ -55,11 +52,6 @@ public class AndroidPublishExecutorTests
     [Fact]
     public async Task Publish_retries_once_on_xardf7024_and_succeeds()
     {
-        if (AndroidPublishExecutor.IsHostUnsupported)
-        {
-            return;
-        }
-
         var workingDir = Path.Combine(Path.GetTempPath(), $"deployer-test-{Guid.NewGuid():N}");
         var staleObj = Path.Combine(workingDir, "obj", "Release", "net10.0-android", "android", "assets", "arm64-v8a");
         Directory.CreateDirectory(staleObj);
@@ -96,11 +88,6 @@ public class AndroidPublishExecutorTests
     [Fact]
     public async Task Publish_does_not_retry_on_unrelated_failures()
     {
-        if (AndroidPublishExecutor.IsHostUnsupported)
-        {
-            return;
-        }
-
         var fake = new ScriptedCommand([
             Result.Failure<string>("error CS0103: The name 'Foo' does not exist")
         ]);


### PR DESCRIPTION
Closes #60.

Removes the unconditional fail-fast for Linux/arm64 hosts in `AndroidPublishExecutor` and bootstraps the [SuperJMN/DotnetAndroidArm64Shims](https://github.com/SuperJMN/DotnetAndroidArm64Shims) overlay before SDK/JDK provisioning.

## Changes

- **New** `AndroidArm64ShimInstaller` invokes the upstream `install-shims.sh` bootstrap via `bash -c "set -o pipefail; curl -fsSL <url> | bash"`. Memoized per process; failure is **not** memoized so retries work.
- `AndroidPrerequisitesInstaller.Ensure()` calls the shim installer first on Linux/arm64, before SDK/JDK provisioning.
- `AndroidPublishExecutor`: `IsHostUnsupported` → `IsHostNativelySupported` + new `IsHostShimmable`; no longer aborts on Linux/arm64.
- 4 new tests for the installer (applicability, no-op on x64, install+memoize on arm64, failure-not-memoized).
- Existing publish tests updated for the new property names.
- `docs/android-on-non-x64-linux.md` rewritten — status changed from "blocked" to "works via shim overlay".

## Validation

End-to-end on a Raspberry Pi 4 (Debian 11, aarch64, .NET 10.0.202):

| Step | Result |
|---|---|
| 4 unit tests for `AndroidArm64ShimInstaller` (arm64 branches) | ✅ 4/4 |
| Smoke E2E: installer called twice (idempotency) | ✅ |
| `aapt2` post-overlay | ELF arm64 ✅ |
| `dotnet new android` + `dotnet publish -c Release -f net10.0-android` | ✅ signed APK + AAB in ~3m52s |
| `adb install -r` + `am start` on real device | ✅ process running, .NET runtime init clean |

121/121 unit tests still pass on x64.
