### PR TITLE
fix(android): stale-APK guard false positive on deterministic builds

### DIFF
--- a/src/DotnetDeployer/Packaging/Android/ApkGenerator.cs
+++ b/src/DotnetDeployer/Packaging/Android/ApkGenerator.cs
@@ -120,18 +120,28 @@ public class ApkGenerator : IPackageGenerator
         // build when only -p:ApplicationVersion / -p:ApplicationDisplayVersion
         // change, so a workspace polluted by a previous job (e.g. a DotnetFleet
         // worker that didn't clean bin/) can leave us with a perfectly valid APK
-        // for the WRONG version. If the APK is older than when this publish
-        // started, the publish was a no-op and the APK is stale.
+        // for the WRONG version.
+        //
+        // We can't compare the APK file's own mtime against publishStartedUtc:
+        // deterministic builds rewrite the APK file's mtime to a fixed epoch
+        // (typically 1980/1981, the ZIP DOS epoch) so a freshly produced APK
+        // looks ancient on disk. Instead we look at the *directory* mtime, which
+        // updates when MSBuild creates/renames the APK inside it but is unaffected
+        // by reproducible-build timestamp rewriting on the file content.
+        var apkDir = IOPath.GetDirectoryName(apkFiles[0])!;
+        var apkDirLastWriteUtc = Directory.GetLastWriteTimeUtc(apkDir);
         var apkLastWriteUtc = File.GetLastWriteTimeUtc(apkFiles[0]);
-        if (apkLastWriteUtc < publishStartedUtc)
+        var freshestSignalUtc = apkDirLastWriteUtc > apkLastWriteUtc ? apkDirLastWriteUtc : apkLastWriteUtc;
+        if (freshestSignalUtc < publishStartedUtc)
         {
             return Result.Failure<GeneratedPackage>(
                 $"Stale APK detected: {apkFiles[0]} was last written at {apkLastWriteUtc:O} " +
-                $"but the publish started at {publishStartedUtc:O}. This usually means " +
-                $"MSBuild's incremental build reused a previous job's output (the .NET " +
-                $"Android SDK does not treat ApplicationVersion as an invalidating input). " +
-                $"Run the publish on a clean workspace (delete bin/ and obj/ for the " +
-                $"Android project, or use 'git clean -fdx').");
+                $"and its directory at {apkDirLastWriteUtc:O}, but the publish started at " +
+                $"{publishStartedUtc:O}. This usually means MSBuild's incremental build " +
+                $"reused a previous job's output (the .NET Android SDK does not treat " +
+                $"ApplicationVersion as an invalidating input). Run the publish on a clean " +
+                $"workspace (delete bin/ and obj/ for the Android project, or use " +
+                $"'git clean -fdx').");
         }
 
         // Use standardized naming


### PR DESCRIPTION
## Problem

User reported a false positive while deploying `Pokemon`:

```
[00:50:45 ERR] Failed to generate Apk (Arm64): Stale APK detected:
.../com.pokemonbattleengine.gui-Signed.apk was last written at
1981-01-01T00:01:02.0000000Z but the publish started at
2026-04-23T22:49:33.2492684Z. This usually means MSBuild's incremental
build reused a previous job's output...
```

The APK was actually fresh — the `dotnet publish` invocation finished a
fraction of a second before the guard ran. The .NET Android SDK rewrites
the APK file's mtime to the **ZIP DOS epoch** (1980/1981) for reproducible
builds, so any freshly produced APK looks ancient on disk.

## Fix

Use the **directory** mtime as the freshness signal in addition to the file
mtime. The directory inode mtime updates whenever MSBuild creates/renames
the APK inside `publish/`, but is **not** subject to reproducible-build
timestamp rewriting on file content.

Verified on the user's actual workspace:
- `publish/` mtime: `2026-04-24 00:50:45` ← real wall clock
- `*.apk` mtime: `1981-01-01 01:01:02` ← deterministic stamp

We now take the freshest of `(file mtime, dir mtime)` and only flag stale
when **both** predate the publish start. The error message also includes
both timestamps for diagnostics.

## Tests

122/122 pass on x64. The guard's purpose (catch incremental no-op
reuse from a previous worker job) is preserved: in that scenario nothing
in `publish/` is touched, so directory mtime stays old too.

Closes the regression introduced by e303221.
