### PR TITLE
[codex] Prevent partial GitHub releases on package failure

### DIFF
--- a/src/DotnetDeployer/Domain/GeneratedPackage.cs
+++ b/src/DotnetDeployer/Domain/GeneratedPackage.cs
@@ -7,6 +7,8 @@ namespace DotnetDeployer.Domain;
 /// </summary>
 public sealed class GeneratedPackage : IDisposable
 {
+    private bool isDisposed;
+
     public required string FileName { get; init; }
     public required PackageType Type { get; init; }
     public required Architecture Architecture { get; init; }
@@ -14,6 +16,13 @@ public sealed class GeneratedPackage : IDisposable
 
     public void Dispose()
     {
+        if (isDisposed)
+        {
+            return;
+        }
+
+        isDisposed = true;
+
         if (Content is IDisposable disposable)
         {
             disposable.Dispose();

--- a/src/DotnetDeployer/Orchestration/DeploymentOrchestrator.cs
+++ b/src/DotnetDeployer/Orchestration/DeploymentOrchestrator.cs
@@ -235,9 +235,22 @@ public class DeploymentOrchestrator
         var version = await DetermineVersion(configDir, options, logger);
         logger.Information("Deploying version {Version}", version);
 
-        var packages = GeneratePackages(config, configDir, version, logger);
+        var packagesResult = await GeneratePackages(config, configDir, version, logger);
+        if (packagesResult.IsFailure)
+        {
+            return Result.Failure(packagesResult.Error);
+        }
 
-        return await githubDeployer.Deploy(config, version, packages, options.DryRun, logger);
+        var packages = packagesResult.Value;
+
+        try
+        {
+            return await githubDeployer.Deploy(config, version, EnumeratePackages(packages), options.DryRun, logger);
+        }
+        finally
+        {
+            DisposePackages(packages);
+        }
     }
 
     private async Task<Result> GeneratePackagesOnly(
@@ -246,119 +259,135 @@ public class DeploymentOrchestrator
         string version,
         ILogger logger)
     {
-        var count = 0;
-        await foreach (var package in GeneratePackages(config, configDir, version, logger))
+        var packagesResult = await GeneratePackages(config, configDir, version, logger);
+        if (packagesResult.IsFailure)
         {
-            count++;
+            return Result.Failure(packagesResult.Error);
+        }
+
+        var packages = packagesResult.Value;
+        foreach (var package in packages)
+        {
             logger.Information("Generated package: {FileName}", package.FileName);
             package.Dispose();
         }
 
-        return count == 0
+        return packages.Count == 0
             ? Result.Failure("No packages were generated.")
             : Result.Success();
     }
 
-    private async IAsyncEnumerable<GeneratedPackage> GeneratePackages(
+    private async Task<Result<List<GeneratedPackage>>> GeneratePackages(
         GitHubConfig config,
         string configDir,
         string version,
-        ILogger logger,
-        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        ILogger logger)
     {
-        // Use custom output directory if specified, otherwise use temp
+        // Use custom output directory if specified, otherwise use config directory.
         string outputDir;
-        bool cleanupOnFinish;
 
         if (!string.IsNullOrEmpty(config.OutputDir))
         {
             outputDir = Path.IsPathRooted(config.OutputDir)
                 ? config.OutputDir
                 : Path.Combine(configDir, config.OutputDir);
-            cleanupOnFinish = false;
         }
         else
         {
             // Default to config directory (where deployer.yaml is)
             outputDir = configDir;
-            cleanupOnFinish = false;
         }
 
         logger.Information("Packages will be saved to: {OutputDir}", outputDir);
         Directory.CreateDirectory(outputDir);
 
-        try
+        var packages = new List<GeneratedPackage>();
+        var errors = new List<string>();
+
+        foreach (var projectConfig in config.Packages)
         {
-            foreach (var projectConfig in config.Packages)
+            var projectPath = Path.IsPathRooted(projectConfig.Project)
+                ? projectConfig.Project
+                : Path.Combine(configDir, projectConfig.Project);
+
+            logger.Debug("Processing project: {Project}", projectPath);
+
+            var metadataResult = await metadataExtractor.Extract(projectPath);
+            if (metadataResult.IsFailure)
             {
-                var projectPath = Path.IsPathRooted(projectConfig.Project)
-                    ? projectConfig.Project
-                    : Path.Combine(configDir, projectConfig.Project);
+                var error = $"Failed to extract metadata from {projectPath}: {metadataResult.Error}";
+                logger.Error("{Error}", error);
+                errors.Add(error);
+                continue;
+            }
 
-                logger.Debug("Processing project: {Project}", projectPath);
+            var metadata = metadataResult.Value;
 
-                var metadataResult = await metadataExtractor.Extract(projectPath);
-                if (metadataResult.IsFailure)
+            // Override version with the global version from GitVersion
+            metadata = metadata with { Version = version };
+
+            foreach (var formatConfig in projectConfig.Formats)
+            {
+                var packageType = formatConfig.GetPackageType();
+                var generator = generatorFactory.GetGenerator(formatConfig);
+
+                foreach (var arch in formatConfig.GetArchitectures())
                 {
-                    logger.Error("Failed to extract metadata from {Project}: {Error}", projectPath, metadataResult.Error);
-                    continue;
-                }
+                    logger.Information("Generating {Type} ({Arch}) for {Project}", packageType, arch, metadata.AssemblyName);
 
-                var metadata = metadataResult.Value;
+                    var phaseName = $"package.generate.{packageType.ToString().ToLowerInvariant()}.{arch.ToString().ToLowerInvariant()}";
+                    var pkgPhase = phases.BeginPhase(phaseName,
+                        ("project", metadata.AssemblyName ?? ""),
+                        ("type", packageType.ToString()),
+                        ("arch", arch.ToString()));
 
-                // Override version with the global version from GitVersion
-                metadata = metadata with { Version = version };
+                    var result = await generator.Generate(projectPath, arch, metadata, outputDir, logger);
 
-                foreach (var formatConfig in projectConfig.Formats)
-                {
-                    var packageType = formatConfig.GetPackageType();
-                    var generator = generatorFactory.GetGenerator(formatConfig);
-
-                    foreach (var arch in formatConfig.GetArchitectures())
+                    if (result.IsSuccess)
                     {
-                        logger.Information("Generating {Type} ({Arch}) for {Project}", packageType, arch, metadata.AssemblyName);
-
-                        var phaseName = $"package.generate.{packageType.ToString().ToLowerInvariant()}.{arch.ToString().ToLowerInvariant()}";
-                        var pkgPhase = phases.BeginPhase(phaseName,
-                            ("project", metadata.AssemblyName ?? ""),
-                            ("type", packageType.ToString()),
-                            ("arch", arch.ToString()));
-
-                        var result = await generator.Generate(projectPath, arch, metadata, outputDir, logger);
-
-                        if (result.IsSuccess)
-                        {
-                            pkgPhase.AddEndAttribute("file", result.Value.FileName);
-                            pkgPhase.Dispose();
-                            yield return result.Value;
-                        }
-                        else
-                        {
-                            pkgPhase.MarkFailure();
-                            pkgPhase.Dispose();
-                            logger.Error("Failed to generate {Type} ({Arch}): {Error}", packageType, arch, result.Error);
-                        }
+                        pkgPhase.AddEndAttribute("file", result.Value.FileName);
+                        pkgPhase.Dispose();
+                        packages.Add(result.Value);
+                    }
+                    else
+                    {
+                        pkgPhase.MarkFailure();
+                        pkgPhase.Dispose();
+                        var error = $"Failed to generate {packageType} ({arch}) for {metadata.AssemblyName}: {result.Error}";
+                        logger.Error("{Error}", error);
+                        errors.Add(error);
                     }
                 }
             }
         }
-        finally
+
+        if (errors.Count == 0)
         {
-            // Cleanup only if using temp directory
-            if (cleanupOnFinish)
-            {
-                try
-                {
-                    if (Directory.Exists(outputDir))
-                    {
-                        Directory.Delete(outputDir, recursive: true);
-                    }
-                }
-                catch
-                {
-                    // Ignore cleanup errors
-                }
-            }
+            return packages;
+        }
+
+        DisposePackages(packages);
+        return Result.Failure<List<GeneratedPackage>>($"Package generation failed: {string.Join("; ", errors)}");
+    }
+
+    private static async IAsyncEnumerable<GeneratedPackage> EnumeratePackages(
+        IEnumerable<GeneratedPackage> packages,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        foreach (var package in packages)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return package;
+
+            await Task.CompletedTask;
+        }
+    }
+
+    private static void DisposePackages(IEnumerable<GeneratedPackage> packages)
+    {
+        foreach (var package in packages)
+        {
+            package.Dispose();
         }
     }
 

--- a/src/DotnetDeployer/Packaging/PackageGeneratorFactory.cs
+++ b/src/DotnetDeployer/Packaging/PackageGeneratorFactory.cs
@@ -45,7 +45,7 @@ public class PackageGeneratorFactory
         };
     }
 
-    public IPackageGenerator GetGenerator(PackageType type)
+    public virtual IPackageGenerator GetGenerator(PackageType type)
     {
         if (!generators.TryGetValue(type, out var generator))
         {
@@ -55,7 +55,7 @@ public class PackageGeneratorFactory
         return generator;
     }
 
-    public IPackageGenerator GetGenerator(PackageFormatConfig formatConfig)
+    public virtual IPackageGenerator GetGenerator(PackageFormatConfig formatConfig)
     {
         var type = formatConfig.GetPackageType();
 

--- a/test/DotnetDeployer.Tests/Orchestration/DeploymentOrchestratorPackageFailureTests.cs
+++ b/test/DotnetDeployer.Tests/Orchestration/DeploymentOrchestratorPackageFailureTests.cs
@@ -1,0 +1,185 @@
+using CSharpFunctionalExtensions;
+using DotnetDeployer.Configuration;
+using DotnetDeployer.Deployment;
+using DotnetDeployer.Domain;
+using DotnetDeployer.Msbuild;
+using DotnetDeployer.Orchestration;
+using DotnetDeployer.Packaging;
+using Serilog;
+using Serilog.Core;
+
+namespace DotnetDeployer.Tests.Orchestration;
+
+public sealed class DeploymentOrchestratorPackageFailureTests
+{
+    [Fact]
+    public async Task Run_DoesNotDeployGitHubRelease_WhenAnyConfiguredPackageFails()
+    {
+        var testRoot = Path.Combine(Path.GetTempPath(), "dotnet-deployer-package-failure-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(testRoot);
+
+        try
+        {
+            var configPath = Path.Combine(testRoot, "deployer.yaml");
+            var projectPath = Path.Combine(testRoot, "App.csproj");
+            await File.WriteAllTextAsync(configPath, "");
+            await File.WriteAllTextAsync(projectPath, "<Project />");
+
+            var githubDeployer = new RecordingGitHubReleaseDeployer();
+            var generatorFactory = new TestPackageGeneratorFactory(
+                new FailingPackageGenerator(PackageType.Deb, "deb generation failed"),
+                new SuccessfulPackageGenerator(PackageType.Rpm));
+
+            var orchestrator = new DeploymentOrchestrator(
+                logger: Logger.None,
+                configReader: new StaticConfigReader(CreateConfig(projectPath)),
+                metadataExtractor: new StaticMetadataExtractor(projectPath),
+                generatorFactory: generatorFactory,
+                githubDeployer: githubDeployer);
+
+            var result = await orchestrator.Run(
+                configPath,
+                new DeployOptions
+                {
+                    DryRun = true,
+                    VersionOverride = "1.2.3"
+                },
+                Logger.None);
+
+            Assert.True(result.IsFailure);
+            Assert.Contains("deb generation failed", result.Error, StringComparison.Ordinal);
+            Assert.False(githubDeployer.WasCalled);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(testRoot, recursive: true);
+            }
+            catch
+            {
+                // Best-effort cleanup for files held by a failed test run.
+            }
+        }
+    }
+
+    private static DeployerConfig CreateConfig(string projectPath)
+    {
+        return new DeployerConfig
+        {
+            GitHub = new GitHubConfig
+            {
+                Enabled = true,
+                Owner = "owner",
+                Repo = "repo",
+                Packages =
+                [
+                    new ProjectPackagesConfig
+                    {
+                        Project = projectPath,
+                        Formats =
+                        [
+                            new PackageFormatConfig { Type = "deb", Arch = ["x64"] },
+                            new PackageFormatConfig { Type = "rpm", Arch = ["x64"] }
+                        ]
+                    }
+                ]
+            }
+        };
+    }
+
+    private sealed class StaticConfigReader(DeployerConfig config) : IConfigReader
+    {
+        public Result<DeployerConfig> Read(string configPath) => config;
+    }
+
+    private sealed class StaticMetadataExtractor(string projectPath) : IMsbuildMetadataExtractor
+    {
+        public Task<Result<ProjectMetadata>> Extract(string path)
+        {
+            var metadata = new ProjectMetadata
+            {
+                ProjectPath = projectPath,
+                AssemblyName = "App",
+                Version = "0.0.0",
+                IconPath = Maybe<string>.None,
+                IsPackable = true
+            };
+
+            return Task.FromResult(Result.Success(metadata));
+        }
+    }
+
+    private sealed class TestPackageGeneratorFactory(params IPackageGenerator[] generators) : PackageGeneratorFactory
+    {
+        private readonly Dictionary<PackageType, IPackageGenerator> byType = generators.ToDictionary(generator => generator.Type);
+
+        public override IPackageGenerator GetGenerator(PackageFormatConfig formatConfig)
+        {
+            return byType[formatConfig.GetPackageType()];
+        }
+    }
+
+    private sealed class FailingPackageGenerator(PackageType type, string error) : IPackageGenerator
+    {
+        public PackageType Type { get; } = type;
+
+        public Task<Result<GeneratedPackage>> Generate(
+            string projectPath,
+            Architecture arch,
+            ProjectMetadata metadata,
+            string outputPath,
+            ILogger logger)
+        {
+            return Task.FromResult(Result.Failure<GeneratedPackage>(error));
+        }
+    }
+
+    private sealed class SuccessfulPackageGenerator(PackageType type) : IPackageGenerator
+    {
+        public PackageType Type { get; } = type;
+
+        public Task<Result<GeneratedPackage>> Generate(
+            string projectPath,
+            Architecture arch,
+            ProjectMetadata metadata,
+            string outputPath,
+            ILogger logger)
+        {
+            var packagePath = Path.Combine(outputPath, "App.rpm");
+            File.WriteAllText(packagePath, "package");
+
+            var package = new GeneratedPackage
+            {
+                FileName = "App.rpm",
+                Type = Type,
+                Architecture = arch,
+                Content = PackageContent.FromFile(packagePath)
+            };
+
+            return Task.FromResult(Result.Success(package));
+        }
+    }
+
+    private sealed class RecordingGitHubReleaseDeployer : IGitHubReleaseDeployer
+    {
+        public bool WasCalled { get; private set; }
+
+        public async Task<Result> Deploy(
+            GitHubConfig config,
+            string version,
+            IAsyncEnumerable<GeneratedPackage> packages,
+            bool dryRun,
+            ILogger logger)
+        {
+            WasCalled = true;
+
+            await foreach (var package in packages)
+            {
+                package.Dispose();
+            }
+
+            return Result.Success();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Generate the full configured GitHub package set before invoking the release deployer.
- Return a package-generation failure when any configured package fails, instead of continuing with a partial set.
- Dispose generated packages deterministically and make package disposal idempotent.
- Add a regression test proving GitHub release deployment is not called when one configured package fails.

## Validation

- `dotnet test DotnetDeployer.slnx`
- `git diff --check`